### PR TITLE
Generic types

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,4 +4,5 @@ build:
     - ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
     - ASAN_OPTIONS=symbolize=1
   commands:
-    - ./scripts/ci.sh
+    - USE_LAPACK=1 ./scripts/ci.sh
+    - USE_LAPACK=0 ./scripts/ci.sh

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,5 +4,5 @@ build:
     - ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
     - ASAN_OPTIONS=symbolize=1
   commands:
-    - USE_LAPACK=1 ./scripts/ci.sh
-    - USE_LAPACK=0 ./scripts/ci.sh
+    - ANYODE_USE_LAPACK=1 ./scripts/ci.sh
+    - ANYODE_USE_LAPACK=0 ./scripts/ci.sh

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ Notes
 When compiled with ``-DNDEBUG`` then ``AnyODE::buffer_factory`` will return a ``std::unique_ptr`` to an (unitizialized)
 array. When compiled without ``NDEBUG`` it will instead return a ``std::vector`` initizlied with signaling NaN.
 
+When compiled with `ANYODE_USE_LAPACK=1``, will use LAPACK routines for operations on the Jacobian matrix. Otherwise
+will default to hand-rolled equivalents.
+
 
 License
 -------

--- a/cython_def/anyode.pxd
+++ b/cython_def/anyode.pxd
@@ -6,7 +6,7 @@ from libcpp.vector cimport vector
 from libcpp cimport bool
 
 cdef extern from "anyode/anyode.hpp" namespace "AnyODE":
-     cdef cppclass OdeSysBase[T]:
+     cdef cppclass OdeSysBase[Real_t, Int_t]:
          int nfev, njev, njvev
          bool use_get_dx_max
 

--- a/cython_def/anyode_numpy.pxd
+++ b/cython_def/anyode_numpy.pxd
@@ -4,15 +4,21 @@ from cpython.ref cimport PyObject
 from libcpp cimport bool
 from anyode cimport Info
 
+cdef extern from "numpy/arrayobject.h":
+    ctypedef int NPY_TYPES
+
 cdef extern from "anyode/anyode_numpy.hpp" namespace "AnyODE":
-    cdef cppclass PyOdeSys:
-        PyOdeSys(int, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, int, int, int, int, PyObject*,
-                 PyObject*, int)
-        int get_ny()
+    cdef cppclass PyOdeSys[Real_t, Index_t]:
+        PyOdeSys(Index_t, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, int, int, int, int,
+                 PyObject*, PyObject*, Index_t)
+        Index_t get_ny()
+        Index_t get_nnz()
+        NPY_TYPES int_type_tag
+        NPY_TYPES float_type_tag
         int get_nquads()
         int get_nroots()
-        double get_dx0(double, double *) except +
-        double get_dx_max(double, double *) except +
+        Real_t get_dx0(Real_t, Real_t *) except +
+        Real_t get_dx_max(Real_t, Real_t *) except +
         bool autonomous_exprs
         bool use_get_dx_max
         bool record_rhs_xvals
@@ -23,5 +29,5 @@ cdef extern from "anyode/anyode_numpy.hpp" namespace "AnyODE":
         int mlower, mupper, nroots
         Info current_info
         int nfev, njev, njvev
-        int nnz
+        Index_t nnz
         void * integrator

--- a/include/anyode/anyode.hpp
+++ b/include/anyode/anyode.hpp
@@ -1,22 +1,22 @@
 #ifdef ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37
 
-#if ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 != 16
+#if ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 != 19
 #error "Multiple anyode.hpp files included with version mismatch"
 #endif
 
 #else
-#define ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 16
+#define ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 19
 
 #ifndef ANYODE_RESTRICT
-#if defined(__GNUC__)
-#define ANYODE_RESTRICT __restrict__
-#elif defined(_MSC_VER) && _MSC_VER >= 1400
-#define ANYODE_RESTRICT __restrict
-#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-#define ANYODE_RESTRICT restrict
-#else
-#define ANYODE_RESTRICT
-#endif
+  #if defined(__GNUC__)
+    #define ANYODE_RESTRICT __restrict__
+  #elif defined(_MSC_VER) && _MSC_VER >= 1400
+    #define ANYODE_RESTRICT __restrict
+  #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+    #define ANYODE_RESTRICT restrict
+  #else
+    #define ANYODE_RESTRICT
+  #endif
 #endif
 
 #include <memory>
@@ -31,9 +31,8 @@ BEGIN_NAMESPACE(AnyODE)
 struct Info {
     std::unordered_map<std::string, int> nfo_int = {};
     std::unordered_map<std::string, double> nfo_dbl = {};
-    std::unordered_map <std::string, std::vector<double>> nfo_vecdbl = {};
-    std::unordered_map <std::string, std::vector<int>> nfo_vecint = {};
-
+    std::unordered_map<std::string, std::vector<double> > nfo_vecdbl = {};
+    std::unordered_map<std::string, std::vector<int> > nfo_vecint = {};
     void clear() {
         nfo_int.clear();
         nfo_dbl.clear();
@@ -147,10 +146,7 @@ template<class T>
 void ignore(const T &) {
 } // ignore unused parameter compiler warnings, or: `int /* arg */`
 
-enum class Status
-        : int {
-    success = 0, recoverable_error = 1, unrecoverable_error = -1
-};
+enum class Status : int {success = 0, recoverable_error = 1, unrecoverable_error = -1};
 
 template<typename Real_t = double, typename Index_t = int>
 struct OdeSysBase {

--- a/include/anyode/anyode.hpp
+++ b/include/anyode/anyode.hpp
@@ -1,24 +1,23 @@
 #ifdef ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37
 
-#if ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 != 19
+#if ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 != 16
 #error "Multiple anyode.hpp files included with version mismatch"
 #endif
 
 #else
-#define ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 19
+#define ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 16
 
 #ifndef ANYODE_RESTRICT
-  #if defined(__GNUC__)
-    #define ANYODE_RESTRICT __restrict__
-  #elif defined(_MSC_VER) && _MSC_VER >= 1400
-    #define ANYODE_RESTRICT __restrict
-  #elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
-    #define ANYODE_RESTRICT restrict
-  #else
-    #define ANYODE_RESTRICT
-  #endif
+#if defined(__GNUC__)
+#define ANYODE_RESTRICT __restrict__
+#elif defined(_MSC_VER) && _MSC_VER >= 1400
+#define ANYODE_RESTRICT __restrict
+#elif defined (__STDC_VERSION__) && __STDC_VERSION__ >= 199901L
+#define ANYODE_RESTRICT restrict
+#else
+#define ANYODE_RESTRICT
 #endif
-
+#endif
 
 #include <memory>
 #include <cstdlib>
@@ -28,23 +27,24 @@
 #include <anyode/anyode_util.hpp>
 
 BEGIN_NAMESPACE(AnyODE)
+
 struct Info {
     std::unordered_map<std::string, int> nfo_int = {};
     std::unordered_map<std::string, double> nfo_dbl = {};
-    std::unordered_map<std::string, std::vector<double> > nfo_vecdbl = {};
-    std::unordered_map<std::string, std::vector<int> > nfo_vecint = {};
+    std::unordered_map <std::string, std::vector<double>> nfo_vecdbl = {};
+    std::unordered_map <std::string, std::vector<int>> nfo_vecint = {};
+
     void clear() {
         nfo_int.clear();
         nfo_dbl.clear();
         nfo_vecdbl.clear();
         nfo_vecint.clear();
     }
-    void update(
-        const std::unordered_map<std::string, int> &new_int,
-        const std::unordered_map<std::string, double> &new_dbl,
-        const std::unordered_map<std::string, std::vector<double> > &new_vecdbl,
-        const std::unordered_map<std::string, std::vector<int> > &new_vecint)
-    {
+
+    void update(const std::unordered_map<std::string, int> &new_int,
+                const std::unordered_map<std::string, double> &new_dbl,
+                const std::unordered_map <std::string, std::vector<double>> &new_vecdbl,
+                const std::unordered_map <std::string, std::vector<int>> &new_vecint) {
 #define ANYODE_INCREMENT(TOKEN)                     \
         for (const auto &kv : new_ ## TOKEN){       \
             const auto &k = kv.first;               \
@@ -64,8 +64,10 @@ struct Info {
         ANYODE_APPEND(dbl);
 #undef ANYODE_APPEND
     }
+
     template<typename stream_t>
-    void dump_ascii(stream_t& out, const std::string &joiner, const std::string &delimiter) const {
+    void dump_ascii(stream_t &out, const std::string &joiner,
+                    const std::string &delimiter) const {
 #define ANYODE_PRINT(DICT_OF_SCALARS)               \
         for (const auto &kv : DICT_OF_SCALARS){     \
             const auto &k = kv.first;               \
@@ -97,7 +99,6 @@ struct Info {
     }
 };
 
-
 struct Result {
     int nt, ny, nquads, nroots;
     Info info;
@@ -105,21 +106,36 @@ private:
     std::unique_ptr<double[], decltype(std::free) *> m_data;
 public:
     Result() = delete;
-    Result(const Result&) = delete;
-    Result(int nt, int ny, int nquads, int nroots, double * data) :
-        nt(nt), ny(ny), nquads(nquads), nroots(nroots), m_data(data, std::free)
-    {
+
+    Result(const Result &) = delete;
+
+    Result(int nt, int ny, int nquads, int nroots, double *data) :
+            nt(nt), ny(ny), nquads(nquads), nroots(nroots), m_data(data,
+                                                                   std::free) {
     }
-    double &t (int tidx) { return m_data[tidx*(nquads+ny+1)]; }
-    double &y (int tidx, int yidx) { return m_data[tidx*(nquads+ny+1) + 1 + yidx]; }
-    double &q (int tidx, int qidx) { return m_data[tidx*(nquads+ny+1) + 1 + ny + qidx]; }
-    double * get_raw_ptr() const { return m_data.get(); }
+
+    double &t(int tidx) {
+        return m_data[tidx * (nquads + ny + 1)];
+    }
+
+    double &y(int tidx, int yidx) {
+        return m_data[tidx * (nquads + ny + 1) + 1 + yidx];
+    }
+
+    double &q(int tidx, int qidx) {
+        return m_data[tidx * (nquads + ny + 1) + 1 + ny + qidx];
+    }
+
+    double *get_raw_ptr() const {
+        return m_data.get();
+    }
+
     template<typename stream_t>
-    void dump_ascii(stream_t& out) {
+    void dump_ascii(stream_t &out) {
         const auto nyq = ny + nquads;
-        for (int ti=0; ti<nt; ++ti){
+        for (int ti = 0; ti < nt; ++ti) {
             out << t(ti);
-            for (int yqi=0; yqi < nyq; ++yqi){
+            for (int yqi = 0; yqi < nyq; ++yqi) {
                 out << " " << y(ti, yqi);
             }
             out << '\n';
@@ -127,16 +143,22 @@ public:
     }
 };
 
+template<class T>
+void ignore(const T &) {
+} // ignore unused parameter compiler warnings, or: `int /* arg */`
 
-enum class Status : int {success = 0, recoverable_error = 1, unrecoverable_error = -1};
+enum class Status
+        : int {
+    success = 0, recoverable_error = 1, unrecoverable_error = -1
+};
 
-template <typename Real_t=double, typename Index_t=int>
+template<typename Real_t = double, typename Index_t = int>
 struct OdeSysBase {
-    int nfev=0, njev=0, njvev=0;
-    void * integrator = nullptr;
-    void * user_data = nullptr;  // for those who don't want to subclass
+    int nfev = 0, njev = 0, njvev = 0;
+    void *integrator = nullptr;
+    void *user_data = nullptr;  // for those who don't want to subclass
     Info current_info;
-    Real_t default_dx0 = 0.0;  // *may* be used by `get_dx0`, 0 signifies solver default
+    Real_t default_dx0 = 0.0; // *may* be used by `get_dx0`, 0 signifies solver default
     bool autonomous_exprs = false;
     bool use_get_dx_max = false;  // whether get_dx_max should be called
     bool record_rhs_xvals = false;
@@ -144,82 +166,126 @@ struct OdeSysBase {
     bool record_order = false;
     bool record_fpe = false;
     bool record_steps = false;
-    virtual ~OdeSysBase() {}
-    virtual int get_ny() const = 0;
-    virtual int get_mlower() const { return -1; } // -1 denotes "not banded"
-    virtual int get_mupper() const { return -1; } // -1 denotes "not banded"
-    virtual Index_t get_nnz() const { return -1; } // -1 denotes "not sparse"
-    virtual int get_nquads() const { return 0; } // Do not track quadratures by default;
-    virtual int get_nroots() const { return 0; } // Do not look for roots by default;
-    virtual Real_t get_dx0(Real_t /* t */,
-                           const Real_t * const /* y */) {
+
+    virtual ~OdeSysBase() {
+    }
+
+    virtual Index_t get_ny() const = 0;
+
+    virtual int get_mlower() const {
+        return -1;
+    } // -1 denotes "not banded"
+    virtual int get_mupper() const {
+        return -1;
+    } // -1 denotes "not banded"
+    virtual Index_t get_nnz() const {
+        return -1;
+    } // -1 denotes "not sparse"
+    virtual int get_nquads() const {
+        return 0;
+    } // Do not track quadratures by default;
+    virtual int get_nroots() const {
+        return 0;
+    } // Do not look for roots by default;
+    virtual Real_t get_dx0(Real_t /* t */, const Real_t *const /* y */) {
         return default_dx0;
     }
-    virtual Real_t get_dx_max(Real_t /* t */, const Real_t * const /* y */) {
+
+    virtual Real_t get_dx_max(Real_t /* t */, const Real_t *const /* y */) {
         return 0.0;
     }
-    virtual Status rhs(Real_t t, const Real_t * const y, Real_t * const f) = 0;
-    virtual Status quads(Real_t xval, const Real_t * const y, Real_t * const out) {
-        ignore(xval); ignore(y); ignore(out);
+
+    virtual Status rhs(Real_t t, const Real_t *const y, Real_t *const f) = 0;
+
+    virtual Status quads(Real_t xval, const Real_t *const y,
+                         Real_t *const out) {
+        ignore(xval);
+        ignore(y);
+        ignore(out);
         return Status::unrecoverable_error;
     }
-    virtual Status roots(Real_t xval, const Real_t * const y, Real_t * const out) {
-        ignore(xval); ignore(y); ignore(out);
+
+    virtual Status roots(Real_t xval, const Real_t *const y,
+                         Real_t *const out) {
+        ignore(xval);
+        ignore(y);
+        ignore(out);
         return Status::unrecoverable_error;
     }
+
     virtual Status dense_jac_cmaj(Real_t t,
-                                  const Real_t * const ANYODE_RESTRICT y,
-                                  const Real_t * const ANYODE_RESTRICT fy,
-                                  Real_t * const ANYODE_RESTRICT jac,
-                                  long int ldim,
-                                  Real_t * const ANYODE_RESTRICT dfdt=nullptr){
-        ignore(t); ignore(y); ignore(fy); ignore(jac); ignore(ldim); ignore(dfdt);
+                                  const Real_t *const ANYODE_RESTRICT y,
+                                  const Real_t *const ANYODE_RESTRICT fy,
+                                  Real_t *const ANYODE_RESTRICT jac, long int ldim,
+                                  Real_t *const ANYODE_RESTRICT dfdt = nullptr) {
+        ignore(t);
+        ignore(y);
+        ignore(fy);
+        ignore(jac);
+        ignore(ldim);
+        ignore(dfdt);
         return Status::unrecoverable_error;
     }
+
     virtual Status dense_jac_rmaj(Real_t t,
-                                  const Real_t * const ANYODE_RESTRICT y,
-                                  const Real_t * const ANYODE_RESTRICT fy,
-                                  Real_t * const ANYODE_RESTRICT jac,
-                                  long int ldim,
-                                  Real_t * const ANYODE_RESTRICT dfdt=nullptr){
-        ignore(t); ignore(y); ignore(fy); ignore(jac); ignore(ldim); ignore(dfdt);
+                                  const Real_t *const ANYODE_RESTRICT y,
+                                  const Real_t *const ANYODE_RESTRICT fy,
+                                  Real_t *const ANYODE_RESTRICT jac, long int ldim,
+                                  Real_t *const ANYODE_RESTRICT dfdt = nullptr) {
+        ignore(t);
+        ignore(y);
+        ignore(fy);
+        ignore(jac);
+        ignore(ldim);
+        ignore(dfdt);
         return Status::unrecoverable_error;
     }
+
     virtual Status banded_jac_cmaj(Real_t t,
-                                   const Real_t * const ANYODE_RESTRICT y,
-                                   const Real_t * const ANYODE_RESTRICT fy,
-                                   Real_t * const ANYODE_RESTRICT jac,
-                                   long int ldim){
-        ignore(t); ignore(y); ignore(fy); ignore(jac); ignore(ldim);
+                                   const Real_t *const ANYODE_RESTRICT y,
+                                   const Real_t *const ANYODE_RESTRICT fy,
+                                   Real_t *const ANYODE_RESTRICT jac, long int ldim) {
+        ignore(t);
+        ignore(y);
+        ignore(fy);
+        ignore(jac);
+        ignore(ldim);
         throw std::runtime_error("banded_jac_cmaj not implemented.");
         return Status::unrecoverable_error;
     }
+
     virtual Status sparse_jac_csc(Real_t t,
-                                  const Real_t * const ANYODE_RESTRICT y,
-                                  const Real_t * const ANYODE_RESTRICT fy,
-                                  Real_t * const ANYODE_RESTRICT data,
-                                  Index_t * const colptrs,
-                                  Index_t * const rowvals
-                                  ) {
-        ignore(t); ignore(y); ignore(fy); ignore(data); ignore(colptrs); ignore(rowvals);
+                                  const Real_t *const ANYODE_RESTRICT y,
+                                  const Real_t *const ANYODE_RESTRICT fy,
+                                  Real_t *const ANYODE_RESTRICT data, Index_t *const colptrs,
+                                  Index_t *const rowvals) {
+        ignore(t);
+        ignore(y);
+        ignore(fy);
+        ignore(data);
+        ignore(colptrs);
+        ignore(rowvals);
         return Status::unrecoverable_error;
     }
+
     virtual Status sparse_jac_csr(Real_t t,
-                                  const Real_t * const ANYODE_RESTRICT y,
-                                  const Real_t * const ANYODE_RESTRICT fy,
-                                  Real_t * const ANYODE_RESTRICT data,
-                                  Index_t * const rowptrs,
-                                  Index_t * const colvals
-                                  ) {
-        ignore(t); ignore(y); ignore(fy); ignore(data); ignore(rowptrs); ignore(colvals);
+                                  const Real_t *const ANYODE_RESTRICT y,
+                                  const Real_t *const ANYODE_RESTRICT fy,
+                                  Real_t *const ANYODE_RESTRICT data, Index_t *const rowptrs,
+                                  Index_t *const colvals) {
+        ignore(t);
+        ignore(y);
+        ignore(fy);
+        ignore(data);
+        ignore(rowptrs);
+        ignore(colvals);
         return Status::unrecoverable_error;
     }
-    virtual Status jtimes(const Real_t * const ANYODE_RESTRICT vec,
-                          Real_t * const ANYODE_RESTRICT out,
-                          Real_t t,
-                          const Real_t * const ANYODE_RESTRICT y,
-                          const Real_t * const ANYODE_RESTRICT fy
-                          ) {
+
+    virtual Status jtimes(const Real_t *const ANYODE_RESTRICT vec,
+                          Real_t *const ANYODE_RESTRICT out, Real_t t,
+                          const Real_t *const ANYODE_RESTRICT y,
+                          const Real_t *const ANYODE_RESTRICT fy) {
         ignore(vec);
         ignore(out);
         ignore(t);
@@ -227,13 +293,10 @@ struct OdeSysBase {
         ignore(fy);
         return Status::unrecoverable_error;
     }
-    virtual Status prec_setup(Real_t t,
-                            const Real_t * const ANYODE_RESTRICT y,
-                            const Real_t * const ANYODE_RESTRICT fy,
-                            bool jok,
-                            bool& jac_recomputed,
-                            Real_t gamma)
-    {
+
+    virtual Status prec_setup(Real_t t, const Real_t *const ANYODE_RESTRICT y,
+                              const Real_t *const ANYODE_RESTRICT fy, bool jok,
+                              bool &jac_recomputed, Real_t gamma) {
         ignore(t);
         ignore(y);
         ignore(fy);
@@ -242,15 +305,13 @@ struct OdeSysBase {
         ignore(gamma);
         return Status::unrecoverable_error;
     }
+
     virtual Status prec_solve_left(const Real_t t,
-                                   const Real_t * const ANYODE_RESTRICT y,
-                                   const Real_t * const ANYODE_RESTRICT fy,
-                                   const Real_t * const ANYODE_RESTRICT r,
-                                   Real_t * const ANYODE_RESTRICT z,
-                                   Real_t gamma,
-                                   Real_t delta,
-                                   const Real_t * const ANYODE_RESTRICT ewt)
-    {
+                                   const Real_t *const ANYODE_RESTRICT y,
+                                   const Real_t *const ANYODE_RESTRICT fy,
+                                   const Real_t *const ANYODE_RESTRICT r,
+                                   Real_t *const ANYODE_RESTRICT z, Real_t gamma, Real_t delta,
+                                   const Real_t *const ANYODE_RESTRICT ewt) {
         ignore(t);
         ignore(y);
         ignore(fy);
@@ -262,6 +323,7 @@ struct OdeSysBase {
         return Status::unrecoverable_error;
     }
 };
+
 END_NAMESPACE(AnyODE)
 
 #endif /* ANYODE_HPP_D47BAD58870311E6B95F2F58DEFE6E37 */

--- a/include/anyode/anyode_blas_lapack.hpp
+++ b/include/anyode/anyode_blas_lapack.hpp
@@ -1,35 +1,62 @@
 #pragma once
-extern "C" void dgemv_(const char* trans, int* m, int* n, const double* alpha, const double* a, int* lda,
-                       const double* x, int* incx, const double* beta, double* y, int* incy, int sundials__=0);
-extern "C" void sgemv_(const char* trans, int* m, int* n, const float* alpha, const float* a, int* lda,
-                       const float* x, int* incx, const float* beta, float* y, int* incy, int sundials__=0);
 
-extern "C" void dgesvd_(const char* jobu, const char* jobvt, int* m, int* n, const double* a,
-                        int* lda, double* s, double* u, int* ldu, double* vt, int* ldvt,
-                        double* work, int* lwork, int* info );
-extern "C" void sgesvd_(const char* jobu, const char* jobvt, int* m, int* n, const float* a,
-                        int* lda, float* s, float* u, int* ldu, float* vt, int* ldvt,
-                        float* work, int* lwork, int* info );
+extern "C" void dgemv_(const char *trans, int *m, int *n, const double *alpha,
+		const double *a, int *lda, const double *x, int *incx,
+		const double *beta, double *y, int *incy, int sundials__ = 0);
 
-extern "C" void dgetrf_(const int* dim1, const int* dim2, double* a, int* lda, int* ipiv, int* info);
-extern "C" void sgetrf_(const int* dim1, const int* dim2, float* a, int* lda, int* ipiv, int* info);
+extern "C" void sgemv_(const char *trans, int *m, int *n, const float *alpha,
+		const float *a, int *lda, const float *x, int *incx, const float *beta,
+		float *y, int *incy, int sundials__ = 0);
 
-extern "C" void dgetrs_(const char* trans, const int* n, const int* nrhs, double* a, const int* lda, int* ipiv, double * b, const int* ldb, int* info, int sundials__=0);
-extern "C" void sgetrs_(const char* trans, const int* n, const int* nrhs, float* a, const int* lda, int* ipiv, float * b, const int* ldb, int* info, int sundials__=0);
+extern "C" void dgesvd_(const char *jobu, const char *jobvt, int *m, int *n,
+		const double *a, int *lda, double *s, double *u, int *ldu, double *vt,
+		int *ldvt, double *work, int *lwork, int *info);
 
-extern "C" void dgbmv_(const char* trans, int* m, int* n, int* kl, int* ku, const double* alpha, const double* a, int* lda,
-                       const double* x, int* incx, const double* beta, double* y, int* incy, int sundials__=0);
-extern "C" void sgbmv_(const char* trans, int* m, int* n, int* kl, int* ku, const float* alpha, const float* a, int* lda,
-                       const float* x, int* incx, const float* beta, float* y, int* incy, int sundials__=0);
+extern "C" void sgesvd_(const char *jobu, const char *jobvt, int *m, int *n,
+		const float *a, int *lda, float *s, float *u, int *ldu, float *vt,
+		int *ldvt, float *work, int *lwork, int *info);
 
-extern "C" void dgbtrf_(const int* dim1, const int* dim2, const int* kl, const int* ku, double* a, int* lda, int* ipiv, int* info);
-extern "C" void sgbtrf_(const int* dim1, const int* dim2, const int* kl, const int* ku, float* a, int* lda, int* ipiv, int* info);
+extern "C" void dgetrf_(const int *dim1, const int *dim2, double *a, int *lda,
+		int *ipiv, int *info);
 
-extern "C" void dgbtrs_(const char* trans, const int* n, const int* kl, const int* ku, const int* nrhs, double* a,
-                        const int* lda, int* ipiv, double * b, const int* ldb, int *info, int sundials__=0);
-extern "C" void sgbtrs_(const char* trans, const int* n, const int* kl, const int* ku, const int* nrhs, float* a,
-                        const int* lda, int* ipiv, float * b, const int* ldb, int*info, int sundials__=0);
+extern "C" void sgetrf_(const int *dim1, const int *dim2, float *a, int *lda,
+		int *ipiv, int *info);
 
+extern "C" void
+dgetrs_(const char *trans, const int *n, const int *nrhs, double *a,
+		const int *lda, int *ipiv, double *b, const int *ldb, int *info,
+		int sundials__ = 0);
+
+extern "C" void
+sgetrs_(const char *trans, const int *n, const int *nrhs, float *a,
+		const int *lda, int *ipiv, float *b, const int *ldb, int *info,
+		int sundials__ = 0);
+
+extern "C" void
+dgbmv_(const char *trans, int *m, int *n, int *kl, int *ku, const double *alpha,
+		const double *a, int *lda, const double *x, int *incx,
+		const double *beta, double *y, int *incy, int sundials__ = 0);
+
+extern "C" void
+sgbmv_(const char *trans, int *m, int *n, int *kl, int *ku, const float *alpha,
+		const float *a, int *lda, const float *x, int *incx, const float *beta,
+		float *y, int *incy, int sundials__ = 0);
+
+extern "C" void
+dgbtrf_(const int *dim1, const int *dim2, const int *kl, const int *ku,
+		double *a, int *lda, int *ipiv, int *info);
+
+extern "C" void
+sgbtrf_(const int *dim1, const int *dim2, const int *kl, const int *ku,
+		float *a, int *lda, int *ipiv, int *info);
+
+extern "C" void dgbtrs_(const char *trans, const int *n, const int *kl,
+		const int *ku, const int *nrhs, double *a, const int *lda, int *ipiv,
+		double *b, const int *ldb, int *info, int sundials__ = 0);
+
+extern "C" void sgbtrs_(const char *trans, const int *n, const int *kl,
+		const int *ku, const int *nrhs, float *a, const int *lda, int *ipiv,
+		float *b, const int *ldb, int *info, int sundials__ = 0);
 
 #define PROXY_DEFINE(CLS_NAME)                                     \
     template<typename T> struct CLS_NAME ## _callback;
@@ -44,33 +71,47 @@ extern "C" void sgbtrs_(const char* trans, const int* n, const int* kl, const in
 
 namespace AnyODE {
 
-    PROXY_DEFINE(gemv)
-    PROXY_SPECIALIZATION(gemv, float, sgemv_)
-    PROXY_SPECIALIZATION(gemv, double, dgemv_)
+PROXY_DEFINE(gemv)
 
-    PROXY_DEFINE(gesvd)
-    PROXY_SPECIALIZATION(gesvd, float, sgesvd_)
-    PROXY_SPECIALIZATION(gesvd, double, dgesvd_)
+PROXY_SPECIALIZATION(gemv, float, sgemv_)
 
-    PROXY_DEFINE(getrf)
-    PROXY_SPECIALIZATION(getrf, float, sgetrf_)
-    PROXY_SPECIALIZATION(getrf, double, dgetrf_)
+PROXY_SPECIALIZATION(gemv, double, dgemv_)
 
-    PROXY_DEFINE(getrs)
-    PROXY_SPECIALIZATION(getrs, float, sgetrs_)
-    PROXY_SPECIALIZATION(getrs, double, dgetrs_)
+PROXY_DEFINE(gesvd)
 
-    PROXY_DEFINE(gbmv)
-    PROXY_SPECIALIZATION(gbmv, float, sgbmv_)
-    PROXY_SPECIALIZATION(gbmv, double, dgbmv_)
+PROXY_SPECIALIZATION(gesvd, float, sgesvd_)
 
-    PROXY_DEFINE(gbtrf)
-    PROXY_SPECIALIZATION(gbtrf, float, sgbtrf_)
-    PROXY_SPECIALIZATION(gbtrf, double, dgbtrf_)
+PROXY_SPECIALIZATION(gesvd, double, dgesvd_)
 
-    PROXY_DEFINE(gbtrs)
-    PROXY_SPECIALIZATION(gbtrs, float, sgbtrs_)
-    PROXY_SPECIALIZATION(gbtrs, double, dgbtrs_)
+PROXY_DEFINE(getrf)
+
+PROXY_SPECIALIZATION(getrf, float, sgetrf_)
+
+PROXY_SPECIALIZATION(getrf, double, dgetrf_)
+
+PROXY_DEFINE(getrs)
+
+PROXY_SPECIALIZATION(getrs, float, sgetrs_)
+
+PROXY_SPECIALIZATION(getrs, double, dgetrs_)
+
+PROXY_DEFINE(gbmv)
+
+PROXY_SPECIALIZATION(gbmv, float, sgbmv_)
+
+PROXY_SPECIALIZATION(gbmv, double, dgbmv_)
+
+PROXY_DEFINE(gbtrf)
+
+PROXY_SPECIALIZATION(gbtrf, float, sgbtrf_)
+
+PROXY_SPECIALIZATION(gbtrf, double, dgbtrf_)
+
+PROXY_DEFINE(gbtrs)
+
+PROXY_SPECIALIZATION(gbtrs, float, sgbtrs_)
+
+PROXY_SPECIALIZATION(gbtrs, double, dgbtrs_)
 
 }
 

--- a/include/anyode/anyode_blasless.hpp
+++ b/include/anyode/anyode_blasless.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <algorithm> // std::min
 #include <cmath>
 #include <functional>
 

--- a/include/anyode/anyode_blasless.hpp
+++ b/include/anyode/anyode_blasless.hpp
@@ -1,123 +1,125 @@
 #pragma once
-#include <algorithm>  // std::min
+
 #include <cmath>
 #include <functional>
-#include <anyode/anyode_util.hpp>
 
+#include <anyode/anyode.hpp>
 
-BEGIN_NAMESPACE(AnyODE)
+using namespace std;
 
-template <typename Real_t = double>
-struct getrf_callback {
-    void operator()(const int * nr, const int * nc, Real_t * a,
-                    int * lda, int * ipiv, int * info) const noexcept {
-        // Unblocked algorithm for LU decomposition general matrices
-        // employing Doolittle's algorithm with rowswaps.
-        //
-        // ipiv indexing starts at 1 (Fortran compatibility)
-        *info = 0;
-        const int dim = std::min(*nr, *nc);
-        if (dim == 0) return;
+namespace AnyODE {
 
-        auto A = [&](int ri, int ci) -> Real_t& { return a[ci*(*lda) + ri]; };
-        auto swaprows = [&](int ri1, int ri2) { // this is not cache friendly
-            for (int ci=0; ci<dim; ++ci)
-                std::swap(A(ri1, ci), A(ri2, ci));
-        };
+    template<typename Real_t = double>
+    struct getrf_callback {
+        void operator()(const int *nr, const int *nc, Real_t *a,
+                        int *lda, int *ipiv, int *info) const noexcept {
+            // Unblocked algorithm for LU decomposition general matrices
+            // employing Doolittle's algorithm with rowswaps.
+            //
+            // ipiv indexing starts at 1 (Fortran compatibility)
+            *info = 0;
+            const int dim = std::min(*nr, *nc);
+            if (dim == 0) return;
 
-        for (int i=0; i < dim; ++i) {
-            int pivrow = i;
-            Real_t absmax = std::abs(A(i, i));
-            for (int j=i+1; j<*nr; ++j) {
-                // Find pivot
-                Real_t curabs = std::abs(A(j, i));
-                if (curabs > absmax){
-                    absmax = curabs;
-                    pivrow = j;
+            auto A = [&](int ri, int ci) -> Real_t & { return a[ci * (*lda) + ri]; };
+            auto swaprows = [&](int ri1, int ri2) { // this is not cache friendly
+                for (int ci = 0; ci < dim; ++ci)
+                    std::swap(A(ri1, ci), A(ri2, ci));
+            };
+
+            for (int i = 0; i < dim; ++i) {
+                int pivrow = i;
+                Real_t absmax = std::abs(A(i, i));
+                for (int j = i + 1; j < *nr; ++j) {
+                    // Find pivot
+                    Real_t curabs = std::abs(A(j, i));
+                    if (curabs > absmax) {
+                        absmax = curabs;
+                        pivrow = j;
+                    }
+                }
+                if ((absmax == 0) && (*info == 0))
+                    *info = pivrow + 1;
+                ipiv[i] = pivrow + 1;
+                if (pivrow != i) {
+                    // Swap rows
+                    swaprows(i, pivrow);
+                }
+                // Eliminate in column
+                for (int ri = i + 1; ri < *nr; ++ri) {
+                    A(ri, i) /= A(i, i);
+                }
+                // Subtract from rows
+                for (int ci = i + 1; ci < *nc; ++ci) {
+                    const Real_t A_i_ci = A(i, ci);
+                    for (int ri = i + 1; ri < *nr; ++ri) {
+                        A(ri, ci) -= A(ri, i) * A_i_ci;
+                    }
                 }
             }
-            if ((absmax == 0) && (*info == 0))
-                *info = pivrow+1;
-            ipiv[i] = pivrow+1;
-            if (pivrow != i) {
-                // Swap rows
-                swaprows(i, pivrow);
-            }
-            // Eliminate in column
-            for (int ri=i+1; ri<*nr; ++ri){
-                A(ri, i) /= A(i, i);
-            }
-            // Subtract from rows
-            for (int ci=i+1; ci<*nc; ++ci){
-                const Real_t A_i_ci = A(i, ci);
-                for (int ri=i+1; ri<*nr; ++ri){
-                    A(ri, ci) -= A(ri, i)*A_i_ci;
+            ipiv[dim - 1] = dim;
+        }
+    };
+
+
+    template<typename Real_t = double>
+    struct getrs_callback {
+        void operator()(const char *trans, const int *n, const int *nrhs, Real_t *a,
+                        const int *lda, int *ipiv, Real_t *b, const int *ldb, int *info,
+                        int sundials__ = 0) const noexcept {
+            ignore(trans);
+            ignore(sundials__);
+            *info = 0;
+            if (*n < 0) *info = -1;
+            if (*nrhs < 0) *info = -2;
+            if (a == nullptr) *info = -3;
+            if (*lda < 0) *info = -4;
+            if (ipiv == nullptr) *info = -5;
+            if (b == nullptr) *info = -6;
+            if (*ldb < 0) *info = -7;
+            if (*info != 0 || n == 0)
+                return;
+            auto A = [&](const int ri, const int ci) -> Real_t & { return a[ri + ci * (*lda)]; };
+            auto B = [&](const int ri, const int idx) -> Real_t & { return b[ri + idx * (*ldb)]; };
+            for (int k = 0; k < *nrhs; ++k) {
+                for (int i = 0; i < *n; ++i)
+                    if (ipiv[i] - 1 != i)
+                        std::swap(B(i, k), B(ipiv[i] - 1, k));
+                for (int i = 1; i < *n; ++i) {
+                    for (int j = 0; j < i; ++j)
+                        B(i, k) -= A(i, j) * B(j, k);
+                }
+                for (int i = *n - 1; i >= 0; --i) {
+                    for (int j = i + 1; j < *n; ++j)
+                        B(i, k) -= A(i, j) * B(j, k);
+                    B(i, k) /= A(i, i);
                 }
             }
         }
-        ipiv[dim-1] = dim;
-    }
-};
+    };
 
+    template<typename Real_t = double>
+    struct gemv_callback {
+        void operator()(const char *trans, int *m, int *n, const Real_t *alpha,
+                        Real_t *a, int *lda, const Real_t *x, int *incx,
+                        const Real_t *beta, Real_t *y, int *incy, int sundials__ = 0) const noexcept {
+            ignore(incx);
+            ignore(incy);
+            ignore(sundials__);
+            std::function < Real_t & (const int, const int)> A;
+            if (*trans == 'T')
+                A = [&](const int ri, const int ci) -> Real_t & { return a[ri * (*lda) + ci]; };
+            else
+                A = [&](const int ri, const int ci) -> Real_t & { return a[ci * (*lda) + ri]; };
 
-template <typename Real_t = double>
-struct getrs_callback {
-    void operator()(const char * trans, const int * n, const int * nrhs, Real_t * a,
-                    const int * lda, int * ipiv, Real_t * b, const int * ldb, int * info,
-                    int sundials__=0) const noexcept {
-        ignore(trans);
-        ignore(sundials__);
-        *info = 0;
-        if (*n < 0)  *info = -1;
-        if (*nrhs < 0)  *info = -2;
-        if (a == nullptr)  *info = -3;
-        if (*lda < 0)  *info = -4;
-        if (ipiv == nullptr)  *info = -5;
-        if (b == nullptr) *info = -6;
-        if (*ldb < 0) *info = -7;
-        if (*info != 0 || n == 0)
-            return;
-        auto A = [&](const int ri, const int ci) -> Real_t& { return a[ri + ci*(*lda)]; };
-        auto B = [&](const int ri, const int idx) -> Real_t& { return b[ri + idx*(*ldb)]; };
-        for (int k=0; k<*nrhs; ++k){
-            for (int i=0; i<*n; ++i)
-                if (ipiv[i]-1 != i)
-                    std::swap(B(i, k), B(ipiv[i]-1, k));
-            for (int i=1; i<*n; ++i){
-                for (int j=0; j<i; ++j)
-                    B(i, k) -= A(i, j)*B(j, k);
-            }
-            for (int i=*n-1; i>=0; --i){
-                for (int j=i+1; j<*n; ++j)
-                    B(i, k) -= A(i, j)*B(j, k);
-                B(i, k) /= A(i, i);
+            int i, j;
+            Real_t y0;
+
+            for (i = 0; i != *m; i++) {
+                y0 = (*beta) * y[i];
+                for (j = 0; j != *n; j++) y0 += *alpha * A(i, j) * x[j];
+                y[i] = y0;
             }
         }
-    }
-};
-
-template <typename Real_t = double>
-struct gemv_callback {
-    void operator()(const char* trans, int * m, int * n, const Real_t * alpha,
-                    Real_t * a, int * lda, const Real_t * x, int * incx,
-                    const Real_t * beta, Real_t * y, int * incy, int sundials__=0) const noexcept {
-        ignore(incx);
-        ignore(incy);
-        ignore(sundials__);
-        std::function<Real_t& (const int, const int)> A;
-        if (*trans == 'T')
-            A = [&](const int ri, const int ci) -> Real_t& { return a[ri*(*lda) + ci]; };
-        else
-            A = [&](const int ri, const int ci) -> Real_t& { return a[ci*(*lda) + ri]; };
-
-        int i, j;
-        Real_t y0;
-
-        for (i=0; i != *m; i++) {
-            y0 = (*beta) * y[i];
-            for (j=0; j != *n; j++) y0 += *alpha * A(i, j) * x[j];
-            y[i] = y0;
-        }
-    }
-};
-END_NAMESPACE(AnyODE)
+    };
+}

--- a/include/anyode/anyode_buffer.hpp
+++ b/include/anyode/anyode_buffer.hpp
@@ -1,10 +1,12 @@
 #pragma once
 
-#include<memory>
+#include <memory>
 
 #ifndef NDEBUG
-#include<vector>
-#include<limits>
+
+#include <vector>
+#include <limits>
+
 #endif
 
 namespace AnyODE {
@@ -12,28 +14,31 @@ namespace AnyODE {
 #if __cplusplus >= 201402L
     using std::make_unique;
 #else
-    template <class T, class ...Args>
+    template<class T, class ...Args>
     typename std::enable_if
-    <
-        !std::is_array<T>::value,
-        std::unique_ptr<T>
-        >::type
-    make_unique(Args&& ...args)
-    {
+            <
+                    !std::is_array<T>::value,
+                    std::unique_ptr < T>
+    >
+
+    ::type
+    make_unique(Args &&...args) {
         return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
     }
 
-    template <class T>
+    template<class T>
     typename std::enable_if
-    <
-        std::is_array<T>::value,
-        std::unique_ptr<T>
-        >::type
-    make_unique(std::size_t n)
-    {
+            <
+                    std::is_array<T>::value,
+                    std::unique_ptr < T>
+    >
+
+    ::type
+    make_unique(std::size_t n) {
         typedef typename std::remove_extent<T>::type RT;
         return std::unique_ptr<T>(new RT[n]);
     }
+
 #endif
 
 #ifdef NDEBUG
@@ -51,15 +56,22 @@ namespace AnyODE {
 
 #else
     template<typename T> using buffer_t = std::vector<T>;
-    template<typename T> using buffer_ptr_t = T*;
-    template<typename T> inline constexpr buffer_t<T> buffer_factory(std::size_t n) {
+    template<typename T> using buffer_ptr_t = T *;
+
+    template<typename T>
+    inline constexpr buffer_t<T> buffer_factory(std::size_t n) {
         return buffer_t<T>(n, std::numeric_limits<T>::signaling_NaN());
     }
-    template<typename T> constexpr T* buffer_get_raw_ptr(buffer_t<T>& buf) {
+
+    template<typename T>
+    constexpr T *buffer_get_raw_ptr(buffer_t<T> &buf) {
         return &buf[0];
     }
-    template<typename T> constexpr bool buffer_is_initialized(const buffer_t<T>& buf) {
+
+    template<typename T>
+    constexpr bool buffer_is_initialized(const buffer_t<T> &buf) {
         return buf.size() > 0;
     }
+
 #endif
 }

--- a/include/anyode/anyode_decomposition.hpp
+++ b/include/anyode/anyode_decomposition.hpp
@@ -2,13 +2,13 @@
 
 #include <cmath>
 
-#include "anyode/anyode_matrix.hpp"
-#include "anyode/anyode_buffer.hpp"
+#include <anyode/anyode_buffer.hpp>
+#include <anyode/anyode_matrix.hpp>
 
-#if ANYODE_NO_LAPACK == 1
-#include "anyode/anyode_blasless.hpp"
+#if USE_LAPACK == 1
+#include <anyode/anyode_blas_lapack.hpp>
 #else
-#include "anyode/anyode_blas_lapack.hpp"
+#include <anyode/anyode_blasless.hpp>
 #endif
 
 namespace AnyODE {
@@ -16,35 +16,38 @@ namespace AnyODE {
     template<typename Real_t>
     struct DecompositionBase {
         virtual ~DecompositionBase() {};
+
         virtual int factorize() = 0;
-        virtual int solve(const Real_t * const, Real_t * const) = 0;
+
+        virtual int solve(const Real_t *const, Real_t *const) = 0;
     };
 
     template<typename Real_t = double>
     struct DenseLU : public DecompositionBase<Real_t> {
         // DenseLU_callbacks<Real_t> m_cbs;
-        DenseMatrix<Real_t> * m_view;
+        DenseMatrix <Real_t> *m_view;
         buffer_t<int> m_ipiv;
 
-        DenseLU(DenseMatrix<Real_t> * view) :
-            m_view(view),
-            m_ipiv(buffer_factory<int>(view->m_nr))
-        {}
+        DenseLU(DenseMatrix <Real_t> *view) :
+                m_view(view),
+                m_ipiv(buffer_factory<int>(view->m_nr)) {}
+
         int factorize() override final {
             int info;
-            constexpr getrf_callback<Real_t> getrf{};
+            constexpr getrf_callback <Real_t> getrf{};
             getrf(&(m_view->m_nr), &(m_view->m_nc), m_view->m_data, &(m_view->m_ld),
-                          buffer_get_raw_ptr(m_ipiv), &info);
+                  buffer_get_raw_ptr(m_ipiv), &info);
             return info;
         }
-        int solve(const Real_t * const b, Real_t * const x) override final {
+
+        int solve(const Real_t *const b, Real_t *const x) override final {
             char trans = 'N';
             int nrhs = 1;
             int info;
             std::copy(b, b + m_view->m_nr, x);
-            constexpr getrs_callback<Real_t> getrs{};
+            constexpr getrs_callback <Real_t> getrs{};
             getrs(&trans, &(m_view->m_nr), &nrhs, m_view->m_data, &(m_view->m_ld),
-                          buffer_get_raw_ptr(m_ipiv), x, &(m_view->m_nr), &info);
+                  buffer_get_raw_ptr(m_ipiv), x, &(m_view->m_nr), &info);
             return info;
         }
     };
@@ -66,5 +69,4 @@ namespace AnyODE {
             return 0;
         }
     };
-
 }

--- a/include/anyode/anyode_decomposition.hpp
+++ b/include/anyode/anyode_decomposition.hpp
@@ -5,7 +5,11 @@
 #include <anyode/anyode_buffer.hpp>
 #include <anyode/anyode_matrix.hpp>
 
-#if USE_LAPACK == 1
+#ifndef ANYODE_USE_LAPACK
+#define ANYODE_USE_LAPACK 0
+#endif
+
+#if ANYODE_USE_LAPACK == 1
 #include <anyode/anyode_blas_lapack.hpp>
 #else
 #include <anyode/anyode_blasless.hpp>

--- a/include/anyode/anyode_matrix.hpp
+++ b/include/anyode/anyode_matrix.hpp
@@ -5,7 +5,11 @@
 #include <cstring>  // std::memset
 #include <stdexcept> // std::runtime_error
 
-#if USE_LAPACK == 1
+#ifndef ANYODE_USE_LAPACK
+#define ANYODE_USE_LAPACK 0
+#endif
+
+#if ANYODE_USE_LAPACK == 1
 #include "anyode/anyode_blas_lapack.hpp"
 #else
 #include "anyode/anyode_blasless.hpp"
@@ -173,7 +177,7 @@ namespace AnyODE {
         }
     };
 
-#if USE_LAPACK == 1
+#if ANYODE_USE_LAPACK == 1
     constexpr int banded_padded_ld(int kl, int ku) { return 2*kl+ku+1; }
 
     template<typename Real_t = double>

--- a/include/anyode/anyode_matrix.hpp
+++ b/include/anyode/anyode_matrix.hpp
@@ -1,104 +1,131 @@
 #pragma once
-#include <cstdlib>  // std::aligned_alloc (C++17) & std::free
+
 #include <stdint.h> // uintptr_t
+#include <cstdlib>  // std::aligned_alloc (C++17) & std::free
 #include <cstring>  // std::memset
 #include <stdexcept> // std::runtime_error
 
-#if ANYODE_NO_LAPACK == 1
-#include "anyode/anyode_blasless.hpp"
-#else
+#if USE_LAPACK == 1
 #include "anyode/anyode_blas_lapack.hpp"
+#else
+#include "anyode/anyode_blasless.hpp"
 #endif
 
 namespace AnyODE {
-    template<typename T> constexpr std::size_t n_padded(std::size_t n, int alignment_bytes){
-        return ((n*sizeof(T) + alignment_bytes - 1) & ~(alignment_bytes - 1)) / sizeof(T);
+    template<typename T>
+    constexpr std::size_t n_padded(std::size_t n, int alignment_bytes) {
+        return ((n * sizeof(T) + alignment_bytes - 1) & ~(alignment_bytes - 1)) / sizeof(T);
     }
+
     static constexpr int alignment_bytes_ = 64; // L1 cache line
 
     template<typename Real_t>
     class MatrixBase {
-        void * m_own_array_ = nullptr;
-        Real_t * alloc_array_(int n){
-            m_own_array_ = std::malloc(sizeof(Real_t)*n + alignment_bytes_ - 1);
+        void *m_own_array_ = nullptr;
+
+        Real_t *alloc_array_(int n) {
+            m_own_array_ = std::malloc(sizeof(Real_t) * n + alignment_bytes_ - 1);
             const uintptr_t mask = ~uintptr_t(alignment_bytes_ - 1);
             const uintptr_t addr = reinterpret_cast<uintptr_t>(m_own_array_);
             const uintptr_t candidate = addr + alignment_bytes_ - 1;
             return static_cast<Real_t *>(reinterpret_cast<void *>(candidate & mask));
         }
+
     public:
 
-        Real_t * m_data;
+        Real_t *m_data;
         int m_nr, m_nc, m_ld, m_ndata;
         bool m_own_data;
-        MatrixBase(Real_t * const data, int nr, int nc, int ld, int ndata, bool own_data=false) :
-            m_data(data ? data : alloc_array_(ndata)), m_nr(nr), m_nc(nc), m_ld(ld), m_ndata(ndata),
-            m_own_data(own_data)
-        {
-            if (data == nullptr && own_data)
+
+        MatrixBase(Real_t *const data, int nr, int nc, int ld, int ndata, bool own_data = false) :
+                m_data(data ? data : alloc_array_(ndata)), m_nr(nr), m_nc(nc), m_ld(ld), m_ndata(ndata),
+                m_own_data(own_data) {
+            if (data == nullptr and own_data)
                 throw std::runtime_error("own_data not needed for nullptr");
         }
-        MatrixBase(const MatrixBase<Real_t>& ori) : MatrixBase(nullptr, ori.m_nr, ori.m_nc, ori.m_ld, ori.m_ndata) {
+
+        MatrixBase(const MatrixBase<Real_t> &ori) : MatrixBase(nullptr, ori.m_nr, ori.m_nc, ori.m_ld, ori.m_ndata) {
             std::copy(ori.m_data, ori.m_data + m_ndata, m_data);
         }
-        virtual ~MatrixBase(){
+
+        virtual ~MatrixBase() {
             if (m_own_array_)
                 std::free(m_own_array_);
-            if (m_own_data && m_data)
+            if (m_own_data and m_data)
                 std::free(m_data);
         }
-        virtual Real_t& operator()(int /* ri */, int /* ci */) { throw std::runtime_error("Not implemented: operator() in MatrixBase"); }
-        const Real_t& operator()(int ri, int ci) const { return (*const_cast<MatrixBase<Real_t>* >(this))(ri, ci); }
-        virtual bool valid_index(const int ri, const int ci) const {
-            return (0 <= ri) && (ri < this->m_nr) && (0 <= ci) && (ci < this->m_nc);
+
+        virtual Real_t &operator()(int /* ri */, int /* ci */) {
+            throw std::runtime_error("Not implemented: operator() in MatrixBase");
         }
-        virtual bool guaranteed_zero_index(int /* ri */, int /* ci */) const { throw std::runtime_error("Not implemented: guaranteed_zero_index"); };
-        virtual void dot_vec(const Real_t * const, Real_t * const) { throw std::runtime_error("Not implemented: dot_vec"); };
-        virtual void set_to_eye_plus_scaled_mtx(Real_t, const MatrixBase&) { throw std::runtime_error("Not implemented: set_to_eye_plus_scaled_mtx"); };
-        void set_to(Real_t value) noexcept { std::memset(m_data, value, m_ndata*sizeof(Real_t)); }
+
+        const Real_t &operator()(int ri, int ci) const { return (*const_cast<MatrixBase<Real_t> * >(this))(ri, ci); }
+
+        virtual bool valid_index(const int ri, const int ci) const {
+            return (0 <= ri) and (ri < this->m_nr) and (0 <= ci) and (ci < this->m_nc);
+        }
+
+        virtual bool guaranteed_zero_index(int /* ri */, int /* ci */) const {
+            throw std::runtime_error("Not implemented: guaranteed_zero_index");
+        };
+
+        virtual void dot_vec(const Real_t *const, Real_t *const) {
+            throw std::runtime_error("Not implemented: dot_vec");
+        };
+
+        virtual void set_to_eye_plus_scaled_mtx(Real_t, const MatrixBase &) {
+            throw std::runtime_error("Not implemented: set_to_eye_plus_scaled_mtx");
+        };
+
+        void set_to(Real_t value) noexcept { std::memset(m_data, value, m_ndata * sizeof(Real_t)); }
     };
 
     template<typename Real_t = double>
     struct DenseMatrix : public MatrixBase<Real_t> {
         bool m_colmaj;
-        DenseMatrix(Real_t * const data, int nr, int nc, int ld, bool colmaj=true, bool own_data=false) :
-            MatrixBase<Real_t>(data, nr, nc, ld, ld*(colmaj ? nc : nr), own_data),
-            m_colmaj(colmaj)
-        {}
-        DenseMatrix(const DenseMatrix<Real_t>& ori) : MatrixBase<Real_t>(ori), m_colmaj(ori.m_colmaj)
-        {}
-        DenseMatrix(const MatrixBase<Real_t>& source) :
-            MatrixBase<Real_t>(nullptr, source.m_nr, source.m_nc, source.m_nr, source.m_nr*source.m_nc), m_colmaj(true)
-        {
-            for (int imaj = 0; imaj < (m_colmaj ? this->m_nc : this->m_nr); ++imaj){
-                for (int imin = 0; imin < (m_colmaj ? this->m_nr : this->m_nc); ++imin){
+
+        DenseMatrix(Real_t *const data, int nr, int nc, int ld, bool colmaj = true, bool own_data = false) :
+                MatrixBase<Real_t>(data, nr, nc, ld, ld * (colmaj ? nc : nr), own_data),
+                m_colmaj(colmaj) {}
+
+        DenseMatrix(const DenseMatrix<Real_t> &ori) : MatrixBase<Real_t>(ori), m_colmaj(ori.m_colmaj) {}
+
+        DenseMatrix(const MatrixBase<Real_t> &source) :
+                MatrixBase<Real_t>(nullptr, source.m_nr, source.m_nc, source.m_nr, source.m_nr * source.m_nc),
+                m_colmaj(true) {
+            for (int imaj = 0; imaj < (m_colmaj ? this->m_nc : this->m_nr); ++imaj) {
+                for (int imin = 0; imin < (m_colmaj ? this->m_nr : this->m_nc); ++imin) {
                     const int ri = m_colmaj ? imin : imaj;
                     const int ci = m_colmaj ? imaj : imin;
-                    this->m_data[this->m_ld*imaj + imin] = source(ri, ci);
+                    this->m_data[this->m_ld * imaj + imin] = source(ri, ci);
                 }
             }
         }
-        Real_t& operator()(int ri, int ci) noexcept override final {
+
+        Real_t &operator()(int ri, int ci) noexcept override final {
             const int imaj = m_colmaj ? ci : ri;
             const int imin = m_colmaj ? ri : ci;
-            return this->m_data[imaj*this->m_ld + imin];
+            return this->m_data[imaj * this->m_ld + imin];
         }
+
         virtual bool guaranteed_zero_index(const int /* ri */, const int /* ci */) const override { return false; }
-        void dot_vec(const Real_t * const vec, Real_t * const out) override final {
-            Real_t alpha=1, beta=0;
-            int inc=1;
-            char trans= m_colmaj ? 'N' : 'T';
+
+        void dot_vec(const Real_t *const vec, Real_t *const out) override final {
+            Real_t alpha = 1, beta = 0;
+            int inc = 1;
+            char trans = m_colmaj ? 'N' : 'T';
             int sundials_dummy = 0;
-            constexpr gemv_callback<Real_t> gemv{};
+            constexpr gemv_callback <Real_t> gemv{};
             gemv(&trans, &(this->m_nr), &(this->m_nc), &alpha, this->m_data, &(this->m_ld),
                  const_cast<Real_t *>(vec), &inc, &beta, out, &inc, sundials_dummy);
         }
-        void set_to_eye_plus_scaled_mtx(Real_t scale, const MatrixBase<Real_t>& source) override final {
-            for (int imaj = 0; imaj < (m_colmaj ? this->m_nc : this->m_nr); ++imaj){
-                for (int imin = 0; imin < (m_colmaj ? this->m_nr : this->m_nc); ++imin){
+
+        void set_to_eye_plus_scaled_mtx(Real_t scale, const MatrixBase<Real_t> &source) override final {
+            for (int imaj = 0; imaj < (m_colmaj ? this->m_nc : this->m_nr); ++imaj) {
+                for (int imin = 0; imin < (m_colmaj ? this->m_nr : this->m_nc); ++imin) {
                     const int ri = m_colmaj ? imin : imaj;
                     const int ci = m_colmaj ? imaj : imin;
-                    this->m_data[this->m_ld*imaj + imin] = scale*source(ri, ci) + ((imaj == imin) ? 1 : 0);
+                    this->m_data[this->m_ld * imaj + imin] = scale * source(ri, ci) + ((imaj == imin) ? 1 : 0);
                 }
             }
         }
@@ -146,8 +173,7 @@ namespace AnyODE {
         }
     };
 
-
-#if ANYODE_NO_LAPACK != 1
+#if USE_LAPACK == 1
     constexpr int banded_padded_ld(int kl, int ku) { return 2*kl+ku+1; }
 
     template<typename Real_t = double>
@@ -179,7 +205,7 @@ namespace AnyODE {
         }
         virtual bool guaranteed_zero_index(const int ri, const int ci) const override {
             const int delta = ri - ci;
-            return (this->m_ku < delta) || (delta < -(this->m_kl));
+            return (this->m_ku < delta) or (delta < -(this->m_kl));
         }
         void dot_vec(const Real_t * const vec, Real_t * const out) override final {
             Real_t alpha=1, beta=0;

--- a/include/anyode/anyode_numpy.hpp
+++ b/include/anyode/anyode_numpy.hpp
@@ -1,308 +1,439 @@
 #pragma once
 
-#include <Python.h>
 #include <numpy/arrayobject.h>
+#include <Python.h>
+
+#include <anyode/anyode_decomposition.hpp>  // DenseLU
 #include <anyode/anyode_iterative.hpp>
 #include <anyode/anyode_matrix.hpp> // DenseMatrix
-#include <anyode/anyode_decomposition.hpp>  // DenseLU
-
+#include <anyode/anyode_numpy_types.hpp>
 
 BEGIN_NAMESPACE(AnyODE)
-struct PyOdeSys : public AnyODE::OdeSysIterativeBase<double, int, DenseMatrix<double>, DenseLU<double>> {
-    int ny;
-    PyObject *py_rhs, *py_jac, *py_jtimes, *py_quads, *py_roots, *py_kwargs, *py_dx0cb, *py_dx_max_cb;
-    int mlower, mupper, nquads, nroots;
-    int nnz;
-    PyOdeSys(int ny, PyObject * py_rhs, PyObject * py_jac=nullptr, PyObject * py_jtimes=nullptr,
-             PyObject * py_quads=nullptr,
-             PyObject * py_roots=nullptr, PyObject * py_kwargs=nullptr, int mlower=-1,
-             int mupper=-1, int nquads=0, int nroots=0, PyObject * py_dx0cb=nullptr,
-             PyObject * py_dx_max_cb=nullptr, int nnz=-1) :
-        ny(ny), py_rhs(py_rhs), py_jac(py_jac), py_jtimes(py_jtimes),
-        py_quads(py_quads), py_roots(py_roots),
-        py_kwargs(py_kwargs), py_dx0cb(py_dx0cb), py_dx_max_cb(py_dx_max_cb),
-        mlower(mlower), mupper(mupper), nquads(nquads), nroots(nroots),
-        nnz(nnz)
-    {
-        if (py_rhs == nullptr){
-            throw std::runtime_error("py_rhs must not be nullptr");
-        }
-        if ((py_dx_max_cb != nullptr) && (py_dx_max_cb != Py_None)) {
-            this->use_get_dx_max = true;
-        }
-        Py_INCREF(py_rhs);
-        Py_XINCREF(py_jac);
-        Py_XINCREF(py_jtimes);
-        Py_XINCREF(py_quads);
-        Py_XINCREF(py_roots);
-        if (py_kwargs == Py_None){
-            Py_DECREF(Py_None);
-            this->py_kwargs = nullptr;
-        } else {
-            Py_XINCREF(py_kwargs);
-        }
-    }
-    virtual ~PyOdeSys() {
-        Py_DECREF(py_rhs);
-        Py_XDECREF(py_jac);
-        Py_XDECREF(py_jtimes);
-        Py_XDECREF(py_quads);
-        Py_XDECREF(py_roots);
-        Py_XDECREF(py_kwargs);
-    }
-    int get_ny() const override { return ny; }
-    int get_mlower() const override { return mlower; }
-    int get_mupper() const override { return mupper; }
-    int get_nnz() const override { return nnz; }
-    int get_nquads() const override { return nquads; }
-    int get_nroots() const override { return nroots; }
-    double get_dx0(double t, const double * const y) override {
-        if (py_dx0cb == nullptr || py_dx0cb == Py_None) {
-            return default_dx0;
-        }
-        npy_intp dims[1] { static_cast<npy_intp>(this->ny) } ;
-        const auto type_tag = NPY_DOUBLE;
-        PyObject * py_yarr = PyArray_SimpleNewFromData(
-            1, dims, type_tag, static_cast<void*>(const_cast<double*>(y)));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr), NPY_ARRAY_WRITEABLE);  // make yarr read-only
-        PyObject * py_arglist = Py_BuildValue("(dO)", (double)(t), py_yarr);
-        PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_dx0cb, py_arglist, this->py_kwargs);
-        Py_DECREF(py_arglist);
-        Py_DECREF(py_yarr);
-        if (py_result == nullptr) {
-            throw std::runtime_error("get_dx0 failed (dx0cb failed)");
-        }
-        double res = PyFloat_AsDouble(py_result);
-        Py_DECREF(py_result);
-        if ((PyErr_Occurred()) && (res == -1.0)) {
-            throw std::runtime_error("get_dx0 failed (value returned by dx0cb could not be converted to float)");
-        }
-        return res;
-    }
-    double get_dx_max(double t, const double * const y) override {
-        if (py_dx_max_cb == nullptr || py_dx_max_cb == Py_None) {
-            return INFINITY;
-        }
-        npy_intp dims[1] { static_cast<npy_intp>(this->ny) } ;
-        const auto type_tag = NPY_DOUBLE;
-        PyObject * py_yarr = PyArray_SimpleNewFromData(
-            1, dims, type_tag, static_cast<void*>(const_cast<double*>(y)));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr), NPY_ARRAY_WRITEABLE);  // make yarr read-only
-        PyObject * py_arglist = Py_BuildValue("(dO)", (double)(t), py_yarr);
-        PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_dx_max_cb, py_arglist, this->py_kwargs);
-        Py_DECREF(py_arglist);
-        Py_DECREF(py_yarr);
-        if (py_result == nullptr) {
-            throw std::runtime_error("get_dx_max failed (dx_max_cb failed)");
-        }
-        double res = PyFloat_AsDouble(py_result);
-        Py_DECREF(py_result);
-        if (PyErr_Occurred() && (res == -1.0)) {
-            throw std::runtime_error("get_dx_max failed (value returned by dx_max_cb could not be converted to float)");
-        }
-        return res;
-    }
-    Status handle_status_(PyObject * py_result, const std::string what_arg){
-        if (py_result == nullptr){
-            throw std::runtime_error(what_arg + " failed");
-        } else if (py_result == Py_None){
-            Py_DECREF(py_result);
-            return AnyODE::Status::success;
-        }
-        long result = PyInt_AsLong(py_result);
-        Py_DECREF(py_result);
+template<typename Real_t = npy_double, typename Index_t = npy_int>
+struct PyOdeSys: public AnyODE::OdeSysIterativeBase<Real_t, Index_t,
+		DenseMatrix<Real_t>, DenseLU<Real_t>> {
+	Index_t ny;
+	PyObject *py_rhs, *py_jac, *py_jtimes, *py_quads, *py_roots, *py_kwargs,
+			*py_dx0cb, *py_dx_max_cb;
+	int mlower, mupper, nquads, nroots;
+	Index_t nnz;
+	PyOdeSys(Index_t ny, PyObject *py_rhs, PyObject * py_jac = nullptr,
+			 PyObject * py_jtimes = nullptr, PyObject * py_quads = nullptr,
+			 PyObject * py_roots = nullptr, PyObject * py_kwargs = nullptr,
+			 int mlower = -1, int mupper = -1, int nquads = 0, int nroots = 0,
+			 PyObject * py_dx0cb = nullptr, PyObject * py_dx_max_cb = nullptr,
+			 Index_t nnz = -1) :
 
+			 ny(ny), py_rhs(py_rhs), py_jac(py_jac), py_jtimes(py_jtimes),
+			 py_quads(py_quads), py_roots(py_roots), py_kwargs(py_kwargs),
+			 py_dx0cb(py_dx0cb), py_dx_max_cb(py_dx_max_cb), mlower(mlower),
+			 mupper(mupper), nquads(nquads), nroots(nroots), nnz(nnz) {
+		if (py_rhs == nullptr) {
+			throw std::runtime_error("py_rhs must not be nullptr");
+		}
+		if ((py_dx_max_cb != nullptr) && (py_dx_max_cb != Py_None)) {
+			this->use_get_dx_max = true;
+		}
+		Py_INCREF(py_rhs);
+		Py_XINCREF(py_jac);
+		Py_XINCREF(py_jtimes);
+		Py_XINCREF(py_quads);
+		Py_XINCREF(py_roots);
+		if (py_kwargs == Py_None) {
+			Py_DECREF(Py_None);
+			this->py_kwargs = nullptr;
+		} else {
+			Py_XINCREF(py_kwargs);
+		}
+	}
 
-        if ((PyErr_Occurred() && (result == -1)) ||
-            (result == static_cast<long int>(AnyODE::Status::unrecoverable_error))) {
-            return AnyODE::Status::unrecoverable_error;
-        } else if (result == static_cast<long int>(AnyODE::Status::recoverable_error)) {
-            return AnyODE::Status::recoverable_error;
-        } else if (result == static_cast<long int>(AnyODE::Status::success)) {
-            return AnyODE::Status::success;
-        }
-        throw std::runtime_error(what_arg + " did not return None, -1, 0 or 1");
-    }
-    Status rhs(double t, const double * const y, double * const dydt) override {
-        npy_intp dims[1] { static_cast<npy_intp>(this->ny) } ;
-        const auto type_tag = NPY_DOUBLE;
-        PyObject * py_yarr = PyArray_SimpleNewFromData(
-            1, dims, type_tag, static_cast<void*>(const_cast<double*>(y)));
-        PyObject * py_dydt = PyArray_SimpleNewFromData(
-            1, dims, type_tag, static_cast<void*>(dydt));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr), NPY_ARRAY_WRITEABLE);  // make yarr read-only
-        PyObject * py_arglist = Py_BuildValue("(dOO)", (double)(t), py_yarr, py_dydt);
-        PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_rhs, py_arglist, this->py_kwargs);
-        Py_DECREF(py_arglist);
-        Py_DECREF(py_dydt);
-        Py_DECREF(py_yarr);
-        this->nfev++;
-        return handle_status_(py_result, "rhs");
-    }
-    AnyODE::Status quads(double t, const double * const y, double * const out) override {
-        npy_intp ydims[1] { static_cast<npy_intp>(this->ny) };
-        npy_intp rdims[1] { static_cast<npy_intp>(this->get_nquads()) };
-        const auto type_tag = NPY_DOUBLE;
-        PyObject * py_yarr = PyArray_SimpleNewFromData(
-            1, ydims, type_tag, static_cast<void*>(const_cast<double*>(y)));
-        PyObject * py_out = PyArray_SimpleNewFromData(
-            1, rdims, type_tag, static_cast<void*>(out));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr), NPY_ARRAY_WRITEABLE);  // make yarr read-only
-        PyObject * py_arglist = Py_BuildValue("(dOO)", t, py_yarr, py_out);
-        PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_quads, py_arglist, this->py_kwargs);
-        Py_DECREF(py_arglist);
-        Py_DECREF(py_out);
-        Py_DECREF(py_yarr);
-        return handle_status_(py_result, "quads");
-    }
-    AnyODE::Status roots(double t, const double * const y, double * const out) override {
-        npy_intp ydims[1] { static_cast<npy_intp>(this->ny) };
-        npy_intp rdims[1] { static_cast<npy_intp>(this->get_nroots()) };
-        const auto type_tag = NPY_DOUBLE;
-        PyObject * py_yarr = PyArray_SimpleNewFromData(
-            1, ydims, type_tag, static_cast<void*>(const_cast<double*>(y)));
-        PyObject * py_out = PyArray_SimpleNewFromData(
-            1, rdims, type_tag, static_cast<void*>(out));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr), NPY_ARRAY_WRITEABLE);  // make yarr read-only
-        PyObject * py_arglist = Py_BuildValue("(dOO)", t, py_yarr, py_out);
-        PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_roots, py_arglist, this->py_kwargs);
-        Py_DECREF(py_arglist);
-        Py_DECREF(py_out);
-        Py_DECREF(py_yarr);
-        return handle_status_(py_result, "roots");
-    }
-    AnyODE::Status call_py_jac(double t, const double * const y, const double * const fy,
-                               PyObject * py_jmat, double * const dfdt){
-        npy_intp ydims[1] { static_cast<npy_intp>(this->ny) };
-        const auto type_tag = NPY_DOUBLE;
-        PyObject * py_yarr = PyArray_SimpleNewFromData(1, ydims, type_tag, const_cast<double *>(y));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr), NPY_ARRAY_WRITEABLE);  // make yarr read-only
-        PyObject * py_dfdt = (dfdt == nullptr) ? Py_BuildValue("") : PyArray_SimpleNewFromData(
-            1, ydims, type_tag, static_cast<void*>(dfdt));
-        PyObject * py_fy;
-        if (fy) {
-            py_fy = PyArray_SimpleNewFromData(1, ydims, type_tag, const_cast<double *>(fy));
-            PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_fy), NPY_ARRAY_WRITEABLE);  // make fy read-only
-        } else {
-            py_fy = Py_BuildValue(""); // Py_None with incref
-        }
-        // Call jac with signature: (t, y[:], Jmat[:, :], dfdt[:]=None, fy[:]=None)
-        // (NumPy takes cares of row vs. column major ordering. User responsible for dense/banded.)
-        PyObject * py_arglist = Py_BuildValue("(dOOOO)", (double)t, py_yarr, py_jmat, py_dfdt, py_fy);
-        PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_jac, py_arglist, this->py_kwargs);
-        Py_DECREF(py_arglist);
-        Py_DECREF(py_fy);
-        Py_DECREF(py_dfdt);
-        Py_DECREF(py_yarr);
-        this->njev++;
-        return handle_status_(py_result, "jac");
-    }
-    AnyODE::Status jtimes(const double * const v, double * const Jv,
-                          double x, const double * const y, const double * const fy) override {
-        npy_intp ydims[1] { static_cast<npy_intp>(this->ny) };
-        const auto type_tag = NPY_DOUBLE;
-        PyObject * py_yarr = PyArray_SimpleNewFromData(1, ydims, type_tag, const_cast<double *>(y));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr), NPY_ARRAY_WRITEABLE);  // make yarr read-only
-        PyObject * py_varr = PyArray_SimpleNewFromData(1, ydims, type_tag, const_cast<double *>(v));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_varr), NPY_ARRAY_WRITEABLE);  // make varr read-only
-        PyObject * py_Jv = PyArray_SimpleNewFromData(1, ydims, type_tag, const_cast<double *> (Jv));
-        PyObject * py_fy;
-        if (fy) {
-            py_fy = PyArray_SimpleNewFromData(1, ydims, type_tag, const_cast<double *>(fy));
-            PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_fy), NPY_ARRAY_WRITEABLE);  // make fy read-only
-        } else {
-            py_fy = Py_BuildValue(""); // Py_None with incref
-        }
-        // Call jtimes with signature: (v[:], Jv[:], x, y[:], fy[:])
-        PyObject * py_arglist = Py_BuildValue("(OOdOO)", py_varr, py_Jv, (double) x, py_yarr, py_fy);
-        PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_jtimes, py_arglist, this->py_kwargs);
-        Py_DECREF(py_arglist);
-        Py_DECREF(py_Jv);
-        Py_DECREF(py_fy);
-        Py_DECREF(py_yarr);
-        Py_DECREF(py_varr);
-        this->njvev++;
-        return handle_status_(py_result, "jtimes");
-    }
-    AnyODE::Status dense_jac_cmaj(double t, const double * const y, const double * const fy,
-                                  double * const jac, long int ldim, double * const dfdt=nullptr) override {
-        npy_intp Jdims[2] { static_cast<npy_intp>(this->ny), static_cast<npy_intp>(this->ny) };
-        npy_intp strides[2] { sizeof(double), static_cast<npy_intp>(ldim*sizeof(double)) };
-        int flags = NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE;
-        if (ldim == Jdims[0]) {
-            flags |= NPY_ARRAY_F_CONTIGUOUS;
-        }
-        const auto type_tag = NPY_DOUBLE;
-        PyObject * py_jmat = PyArray_New(
-            &PyArray_Type, 2, Jdims, type_tag, strides,
-            static_cast<void *>(const_cast<double *>(jac)), sizeof(double),
-            flags, nullptr);
-        AnyODE::Status status = call_py_jac(t, y, fy, py_jmat, dfdt);
-        Py_DECREF(py_jmat);
-        return status;
-    }
-    AnyODE::Status dense_jac_rmaj(double t, const double * const y, const double * const fy,
-                                  double * const jac, long int ldim, double * const dfdt=nullptr) override {
-        npy_intp Jdims[2] { static_cast<npy_intp>(this->ny), static_cast<npy_intp>(this->ny) };
-        npy_intp strides[2] { static_cast<npy_intp>(ldim*sizeof(double)), sizeof(double) };
-        const auto type_tag = NPY_DOUBLE;
-        int flags = NPY_ARRAY_ALIGNED| NPY_ARRAY_WRITEABLE;
-        if (ldim == Jdims[1]) {
-            flags |= NPY_ARRAY_C_CONTIGUOUS;
-        }
-        PyObject * py_jmat = PyArray_New(
-            &PyArray_Type, 2, Jdims, type_tag, strides,
-            static_cast<void *>(const_cast<double *>(jac)), sizeof(double), flags, nullptr);
-        AnyODE::Status status = call_py_jac(t, y, fy, py_jmat, dfdt);
-        Py_DECREF(py_jmat);
-        return status;
-    }
-    AnyODE::Status sparse_jac_csc(double t, const double * const y, const double * const fy,
-                                  double * const data, int * const colptrs, int * const rowvals) override {
-        npy_intp y_dims[1] { static_cast<npy_intp>(this->ny) };
-        npy_intp data_dims[1] { static_cast<npy_intp>(this->nnz) };
-        npy_intp colptrs_dims[1] { static_cast<npy_intp>(this->ny + 1) };
+	virtual ~PyOdeSys() {
+		Py_DECREF(py_rhs);
+		Py_XDECREF(py_jac);
+		Py_XDECREF(py_jtimes);
+		Py_XDECREF(py_quads);
+		Py_XDECREF(py_roots);
+		Py_XDECREF(py_kwargs);
+	}
 
-        PyObject * py_yarr = PyArray_SimpleNewFromData(1, y_dims, NPY_DOUBLE, const_cast<double *>(y));
-        PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr), NPY_ARRAY_WRITEABLE);  // make yarr read-only
-        PyObject * py_fy;
-        if (fy) {
-            py_fy = PyArray_SimpleNewFromData(1, y_dims, NPY_DOUBLE, const_cast<double *>(fy));
-            PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_fy), NPY_ARRAY_WRITEABLE);  // make fy read-only
-        } else {
-            py_fy = Py_BuildValue(""); // Py_None with incref
-        }
-        PyObject * py_data = PyArray_SimpleNewFromData(1, data_dims, NPY_DOUBLE, static_cast<double *>(data));
-        PyObject * py_colptrs = PyArray_SimpleNewFromData(1, colptrs_dims, NPY_INT, static_cast<int *>(colptrs));
-        PyObject * py_rowvals = PyArray_SimpleNewFromData(1, data_dims, NPY_INT, static_cast<int *>(rowvals));
+	const static NPY_TYPES index_type_tag = npy_index_type<Index_t>::type_tag;
+	const static NPY_TYPES float_type_tag = npy_real_type<Real_t>::type_tag;
 
-        // Call sparse jac with signature: (t, y[:], data[:], colptrs[:], rowvals[:]
-        PyObject * py_arglist = Py_BuildValue("(dOOOO)", (double) t, py_yarr, py_data, py_colptrs, py_rowvals);
-        PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_jac, py_arglist, this->py_kwargs);
-        Py_DECREF(py_arglist);
-        Py_DECREF(py_fy);
-        Py_DECREF(py_yarr);
-        Py_DECREF(py_data);
-        Py_DECREF(py_colptrs);
-        Py_DECREF(py_rowvals);
-        this->njev++;
-        return handle_status_(py_result, "jac");
-    }
-    AnyODE::Status banded_jac_cmaj(double t, const double * const y, const double * const fy,
-                                   double * const jac, long int ldim) override {
-        npy_intp Jdims[2] { 1 + this->mlower + this->mupper, static_cast<npy_intp>(this->ny) };
-        npy_intp strides[2] { sizeof(double), static_cast<npy_intp>(ldim*sizeof(double)) };
-        const auto type_tag = NPY_DOUBLE;
-        int flags = NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE;
-        if (ldim == Jdims[0] ) {
-            flags |= NPY_ARRAY_F_CONTIGUOUS;
-        }
-        PyObject * py_jmat = PyArray_New(
-            &PyArray_Type, 2, Jdims, type_tag, strides,
-            static_cast<void *>(const_cast<double *>(jac)), sizeof(double), flags, nullptr);
-        AnyODE::Status status = call_py_jac(t, y, fy, py_jmat, nullptr);
-        Py_DECREF(py_jmat);
-        return status;
-    }
+	Index_t get_ny() const
+
+	override {
+		return ny;
+	}
+
+	int get_mlower() const
+
+	override {
+		return mlower;
+	}
+
+	int get_mupper() const
+
+	override {
+		return mupper;
+	}
+
+	Index_t get_nnz() const
+
+	override {
+		return nnz;
+	}
+
+	int get_nquads() const
+
+	override {
+		return nquads;
+	}
+
+	int get_nroots() const
+
+	override {
+		return nroots;
+	}
+
+	Real_t get_dx0(Real_t t, const Real_t * const y)
+
+	override {
+		if (py_dx0cb == nullptr || py_dx0cb == Py_None) {
+			return this->default_dx0;
+		}
+		npy_intp dims[1] { static_cast<npy_intp>(this->ny) };
+		PyObject *py_yarr = PyArray_SimpleNewFromData(1, dims,
+				this->float_type_tag,
+				static_cast<void *>(const_cast<Real_t *>(y)));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr),
+				NPY_ARRAY_WRITEABLE);  // make yarr read-only
+		PyObject *py_arglist = Py_BuildValue("(dO)", (double) t, py_yarr);
+		PyObject *py_result = PyEval_CallObjectWithKeywords(this->py_dx0cb,
+				py_arglist, this->py_kwargs);
+		Py_DECREF(py_arglist);
+		Py_DECREF(py_yarr);
+		if (py_result == nullptr) {
+			throw std::runtime_error("get_dx0 failed (dx0cb failed)");
+		}
+		Real_t res = (Real_t) PyFloat_AsDouble(py_result);
+		Py_DECREF(py_result);
+		if ((
+
+		PyErr_Occurred()
+
+		) && (res == -1.0)) {throw std::runtime_error("get_dx0 failed (value returned by dx0cb could not be converted to float)");
+	}
+		return res;
+	}
+
+	Real_t get_dx_max(Real_t t, const Real_t * const y)
+
+	override {
+		if (py_dx_max_cb == nullptr || py_dx_max_cb == Py_None) {
+			return INFINITY;
+		}
+		npy_intp dims[1] { static_cast<npy_intp>(this->ny) };
+		PyObject *py_yarr = PyArray_SimpleNewFromData(1, dims,
+				this->float_type_tag,
+				static_cast<void *>(const_cast<Real_t *>(y)));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr),
+				NPY_ARRAY_WRITEABLE);  // make yarr read-only
+		PyObject *py_arglist = Py_BuildValue("(dO)", (double) t, py_yarr);
+		PyObject *py_result = PyEval_CallObjectWithKeywords(this->py_dx_max_cb,
+				py_arglist, this->py_kwargs);
+		Py_DECREF(py_arglist);
+		Py_DECREF(py_yarr);
+		if (py_result == nullptr) {
+			throw std::runtime_error("get_dx_max failed (dx_max_cb failed)");
+		}
+		Real_t res = (Real_t) PyFloat_AsDouble(py_result);
+		Py_DECREF(py_result);
+		if (
+
+		PyErr_Occurred() &&
+
+		(res == -1.0)) {
+			throw std::runtime_error(
+					"get_dx_max failed (value returned by dx_max_cb could not be converted to float)");
+		}
+		return res;
+	}
+	Status handle_status_(PyObject * py_result, const std::string what_arg) {
+		if (py_result == nullptr) {
+			throw std::runtime_error(what_arg + " failed");
+		} else if (py_result == Py_None) {
+			Py_DECREF(py_result);
+			return AnyODE::Status::success;
+		}
+		long result = PyInt_AsLong(py_result);
+		Py_DECREF(py_result);
+
+		if ((
+
+		PyErr_Occurred() &&
+
+		(result == -1))
+				|| (result
+						== static_cast<long int>(AnyODE::Status::unrecoverable_error))) {
+			return AnyODE::Status::unrecoverable_error;
+		} else if (result
+				== static_cast<long int>(AnyODE::Status::recoverable_error)) {
+			return AnyODE::Status::recoverable_error;
+		} else if (result == static_cast<long int>(AnyODE::Status::success)) {
+			return AnyODE::Status::success;
+		}
+		throw std::runtime_error(what_arg + " did not return None, -1, 0 or 1");
+	}
+
+	Status rhs(Real_t t, const Real_t * const y, Real_t * const dydt)
+
+	override {
+		npy_intp dims[1] { static_cast<npy_intp>(this->ny) };
+		PyObject *py_yarr = PyArray_SimpleNewFromData(1, dims,
+				this->float_type_tag,
+				static_cast<void *>(const_cast<Real_t *>(y)));
+		PyObject *py_dydt = PyArray_SimpleNewFromData(1, dims,
+				this->float_type_tag, static_cast<void *>(dydt));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr),
+				NPY_ARRAY_WRITEABLE);  // make yarr read-only
+		PyObject *py_arglist = Py_BuildValue("(dOO)", (double) t, py_yarr,
+				py_dydt);
+		PyObject *py_result = PyEval_CallObjectWithKeywords(this->py_rhs,
+				py_arglist, this->py_kwargs);
+		Py_DECREF(py_arglist);
+		Py_DECREF(py_dydt);
+		Py_DECREF(py_yarr);
+		this->nfev++;
+		return handle_status_(py_result, "rhs");
+	}
+
+	AnyODE::Status quads(Real_t t, const Real_t * const y, Real_t * const out)
+
+	override {
+		npy_intp ydims[1] { static_cast<npy_intp>(this->ny) };
+		npy_intp rdims[1] { static_cast<npy_intp>(this->get_nquads()) };
+		PyObject *py_yarr = PyArray_SimpleNewFromData(1, ydims,
+				this->float_type_tag,
+				static_cast<void *>(const_cast<Real_t *>(y)));
+		PyObject *py_out = PyArray_SimpleNewFromData(1, rdims,
+				this->float_type_tag, static_cast<void *>(out));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr),
+				NPY_ARRAY_WRITEABLE);  // make yarr read-only
+		PyObject *py_arglist = Py_BuildValue("(dOO)", (double) t, py_yarr,
+				py_out);
+		PyObject *py_result = PyEval_CallObjectWithKeywords(this->py_quads,
+				py_arglist, this->py_kwargs);
+		Py_DECREF(py_arglist);
+		Py_DECREF(py_out);
+		Py_DECREF(py_yarr);
+		return handle_status_(py_result, "quads");
+	}
+
+	AnyODE::Status roots(Real_t t, const Real_t * const y, Real_t * const out)
+
+	override {
+		npy_intp ydims[1] { static_cast<npy_intp>(this->ny) };
+		npy_intp rdims[1] { static_cast<npy_intp>(this->get_nroots()) };
+		PyObject *py_yarr = PyArray_SimpleNewFromData(1, ydims,
+				this->float_type_tag,
+				static_cast<void *>(const_cast<Real_t *>(y)));
+		PyObject *py_out = PyArray_SimpleNewFromData(1, rdims,
+				this->float_type_tag, static_cast<void *>(out));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr),
+				NPY_ARRAY_WRITEABLE);  // make yarr read-only
+		PyObject *py_arglist = Py_BuildValue("(dOO)", (double) t, py_yarr,
+				py_out);
+		PyObject *py_result = PyEval_CallObjectWithKeywords(this->py_roots,
+				py_arglist, this->py_kwargs);
+		Py_DECREF(py_arglist);
+		Py_DECREF(py_out);
+		Py_DECREF(py_yarr);
+		return handle_status_(py_result, "roots");
+	}
+
+	AnyODE::Status call_py_jac(Real_t t, const Real_t * const y,
+			const Real_t * const fy, PyObject *py_jmat, Real_t * const dfdt) {
+		npy_intp ydims[1] { static_cast<npy_intp>(this->ny) };
+		PyObject * py_yarr = PyArray_SimpleNewFromData(1, ydims,
+				this->float_type_tag, const_cast<Real_t *>(y));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject *>(py_yarr),
+				NPY_ARRAY_WRITEABLE);  // make yarr read-only
+		PyObject * py_dfdt =
+				(dfdt == nullptr) ?
+						Py_BuildValue("") :
+						PyArray_SimpleNewFromData(1, ydims,
+								this->float_type_tag,
+								static_cast<void *>(dfdt));
+		PyObject * py_fy;
+		if (fy) {
+			py_fy = PyArray_SimpleNewFromData(1, ydims, this->float_type_tag,
+					const_cast<Real_t *>(fy));
+			PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject *>(py_fy),
+					NPY_ARRAY_WRITEABLE);  // make fy read-only
+		} else {
+			py_fy = Py_BuildValue(""); // Py_None with incref
+		}
+		// Call jac with signature: (t, y[:], Jmat[:, :], dfdt[:]=None, fy[:]=None)
+		// (NumPy takes cares of row vs. column major ordering. User responsible for dense/banded.)
+		PyObject * py_arglist = Py_BuildValue("(dOOOO)", (double) t, py_yarr,
+				py_jmat, py_dfdt, py_fy);
+		PyObject * py_result = PyEval_CallObjectWithKeywords(this->py_jac,
+				py_arglist, this->py_kwargs);
+		Py_DECREF(py_arglist);
+		Py_DECREF(py_fy);
+		Py_DECREF(py_dfdt);
+		Py_DECREF(py_yarr);
+		this->njev++;
+		return handle_status_(py_result, "jac");
+	}
+
+	AnyODE::Status jtimes(const Real_t * const v, Real_t * const Jv, Real_t x,
+			const Real_t * const y, const Real_t * const fy)
+
+			override {
+		npy_intp ydims[1] { static_cast<npy_intp>(this->ny) };
+		PyObject *py_yarr = PyArray_SimpleNewFromData(1, ydims,
+				this->float_type_tag, const_cast<Real_t *>(y));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr),
+				NPY_ARRAY_WRITEABLE);  // make yarr read-only
+		PyObject *py_varr = PyArray_SimpleNewFromData(1, ydims,
+				this->float_type_tag, const_cast<Real_t *>(v));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_varr),
+				NPY_ARRAY_WRITEABLE);  // make varr read-only
+		PyObject *py_Jv = PyArray_SimpleNewFromData(1, ydims,
+				this->float_type_tag, const_cast<Real_t *>(Jv));
+		PyObject * py_fy;
+		if (fy) {
+			py_fy = PyArray_SimpleNewFromData(1, ydims, this->float_type_tag,
+					const_cast<Real_t *>(fy));
+			PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_fy),
+					NPY_ARRAY_WRITEABLE);  // make fy read-only
+		} else {
+			py_fy = Py_BuildValue(""); // Py_None with incref
+		}
+// Call jtimes with signature: (v[:], Jv[:], x, y[:], fy[:])
+		PyObject *py_arglist = Py_BuildValue("(OOdOO)", py_varr, py_Jv,
+				(Real_t) x, py_yarr, py_fy);
+		PyObject *py_result = PyEval_CallObjectWithKeywords(this->py_jtimes,
+				py_arglist, this->py_kwargs);
+		Py_DECREF(py_arglist);
+		Py_DECREF(py_Jv);
+		Py_DECREF(py_fy);
+		Py_DECREF(py_yarr);
+		Py_DECREF(py_varr);
+		this->njvev++;
+		return handle_status_(py_result, "jtimes");
+	}
+
+	AnyODE::Status dense_jac_cmaj(Real_t t, const Real_t * const y,
+			const Real_t * const fy, Real_t * const jac, long int ldim,
+			Real_t * const dfdt = nullptr)
+
+			override {
+		npy_intp Jdims[2] { static_cast<npy_intp>(this->ny),
+				static_cast<npy_intp>(this->ny) };
+		npy_intp strides[2] { sizeof(Real_t), static_cast<npy_intp>(ldim
+				* sizeof(Real_t)) };
+		int flags = NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE;
+		if (ldim == Jdims[0]) {
+			flags |= NPY_ARRAY_F_CONTIGUOUS;
+		}
+		PyObject *py_jmat = PyArray_New(&PyArray_Type, 2, Jdims,
+				this->float_type_tag, strides,
+				static_cast<void *>(const_cast<Real_t *>(jac)), sizeof(Real_t),
+				flags, nullptr);
+		AnyODE::Status status = call_py_jac(t, y, fy, py_jmat, dfdt);
+		Py_DECREF(py_jmat);
+		return status;
+	}
+
+	AnyODE::Status dense_jac_rmaj(Real_t t, const Real_t * const y,
+			const Real_t * const fy, Real_t * const jac, long int ldim,
+			Real_t * const dfdt = nullptr)
+
+			override {
+		npy_intp Jdims[2] { static_cast<npy_intp>(this->ny),
+				static_cast<npy_intp>(this->ny) };
+		npy_intp strides[2] { static_cast<npy_intp>(ldim * sizeof(Real_t)),
+				sizeof(Real_t) };
+		int flags = NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE;
+		if (ldim == Jdims[1]) {
+			flags |= NPY_ARRAY_C_CONTIGUOUS;
+		}
+		PyObject *py_jmat = PyArray_New(&PyArray_Type, 2, Jdims,
+				this->float_type_tag, strides,
+				static_cast<void *>(const_cast<Real_t *>(jac)), sizeof(Real_t),
+				flags, nullptr);
+		AnyODE::Status status = call_py_jac(t, y, fy, py_jmat, dfdt);
+		Py_DECREF(py_jmat);
+		return status;
+	}
+
+	AnyODE::Status sparse_jac_csc(Real_t t, const Real_t * const y,
+			const Real_t * const fy, Real_t * const data, Index_t * const colptrs,
+			Index_t * const rowvals)
+
+			override {
+		npy_intp y_dims[1] { static_cast<npy_intp>(this->ny) };
+		npy_intp data_dims[1] { static_cast<npy_intp>(this->nnz) };
+		npy_intp colptrs_dims[1] { static_cast<npy_intp>(this->ny + 1) };
+
+		PyObject *py_yarr = PyArray_SimpleNewFromData(1, y_dims,
+				this->float_type_tag, const_cast<Real_t *>(y));
+		PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_yarr),
+				NPY_ARRAY_WRITEABLE);  // make yarr read-only
+		PyObject * py_fy;
+		if (fy) {
+			py_fy = PyArray_SimpleNewFromData(1, y_dims, this->float_type_tag,
+					const_cast<Real_t *>(fy));
+			PyArray_CLEARFLAGS(reinterpret_cast<PyArrayObject*>(py_fy),
+					NPY_ARRAY_WRITEABLE);  // make fy read-only
+		} else {
+			py_fy = Py_BuildValue(""); // Py_None with incref
+		}
+		PyObject *py_data = PyArray_SimpleNewFromData(1, data_dims,
+				this->float_type_tag, static_cast<Real_t *>(data));
+
+		PyObject *py_colptrs = PyArray_SimpleNewFromData(1, colptrs_dims,
+				this->index_type_tag, static_cast<Index_t *>(colptrs));
+
+		PyObject *py_rowvals = PyArray_SimpleNewFromData(1, data_dims,
+				this->index_type_tag, static_cast<Index_t *>(rowvals));
+
+// Call sparse jac with signature: (t, y[:], data[:], colptrs[:], rowvals[:]
+		PyObject *py_arglist = Py_BuildValue("(dOOOO)", (double) t, py_yarr,
+				py_data, py_colptrs, py_rowvals);
+		PyObject *py_result = PyEval_CallObjectWithKeywords(this->py_jac,
+				py_arglist, this->py_kwargs);
+		Py_DECREF(py_arglist);
+		Py_DECREF(py_fy);
+		Py_DECREF(py_yarr);
+		Py_DECREF(py_data);
+		Py_DECREF(py_colptrs);
+		Py_DECREF(py_rowvals);
+		this->njev++;
+		return handle_status_(py_result, "jac");
+	}
+
+	AnyODE::Status banded_jac_cmaj(Real_t t, const Real_t * const y,
+			const Real_t * const fy, Real_t * const jac, long int ldim)
+
+			override {
+		npy_intp Jdims[2] { 1 + this->mlower + this->mupper,
+				static_cast<npy_intp>(this->ny) };
+		npy_intp strides[2] { sizeof(Real_t), static_cast<npy_intp>(ldim
+				* sizeof(Real_t)) };
+		int flags = NPY_ARRAY_ALIGNED | NPY_ARRAY_WRITEABLE;
+		if (ldim == Jdims[0]) {
+			flags |= NPY_ARRAY_F_CONTIGUOUS;
+		}
+		PyObject *py_jmat = PyArray_New(&PyArray_Type, 2, Jdims,
+				this->float_type_tag, strides,
+				static_cast<void *>(const_cast<Real_t *>(jac)), sizeof(Real_t),
+				flags, nullptr);
+		AnyODE::Status status = call_py_jac(t, y, fy, py_jmat, nullptr);
+		Py_DECREF(py_jmat);
+		return status;
+	}
 };
 END_NAMESPACE(AnyODE)

--- a/include/anyode/anyode_numpy_types.hpp
+++ b/include/anyode/anyode_numpy_types.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <numpy/arrayobject.h>
+#include <stdint.h>
+
+// Compile-time conversions to (integer-like) numpy TYPENUMs for the "Index_t" PyOdeSys<Real_t, Index_t>
+template<typename T>
+struct has_npy_index_type : std::false_type {
+};
+
+template<typename T>
+struct npy_index_type {
+    static_assert(has_npy_index_type<T>::value, "Cannot find associated numpy integer type for supplied Index_t");
+};
+
+template<>
+struct npy_index_type<int8_t> {
+    const static NPY_TYPES type_tag = NPY_INT8;
+};
+
+template<>
+struct npy_index_type<int16_t> {
+    const static NPY_TYPES type_tag = NPY_INT16;
+};
+
+template<>
+struct npy_index_type<int32_t> {
+    const static NPY_TYPES type_tag = NPY_INT32;
+};
+
+#ifdef INT64_MAX
+template <>
+struct npy_index_type<int64_t>
+{
+    const static NPY_TYPES type_tag = NPY_INT64;
+};
+#endif
+
+// Compile-time conversions to (float-like) numpy TYPENUMs for the "Real_t" in PyOdeSys<Real_t, Index_t>
+template<typename T>
+struct has_npy_real_type : std::false_type {
+};
+
+template<typename T>
+struct npy_real_type {
+    static_assert(has_npy_real_type<T>::value, "Cannot find associated numpy float type for supplied Real_t");
+};
+
+template<>
+struct npy_real_type<float> {
+    const static NPY_TYPES type_tag = NPY_FLOAT;
+};
+
+template<>
+struct npy_real_type<double> {
+    const static NPY_TYPES type_tag = NPY_DOUBLE;
+};
+
+template<>
+struct npy_real_type<long double> {
+    const static NPY_TYPES type_tag = NPY_LONGDOUBLE;
+};

--- a/include/anyode/anyode_parallel.hpp
+++ b/include/anyode/anyode_parallel.hpp
@@ -1,4 +1,5 @@
 #pragma once
+
 #include <exception>
 #include <mutex>
 
@@ -7,22 +8,26 @@ namespace anyode_parallel {
         std::exception_ptr m_exc;
         std::mutex m_lock;
     public:
-        ThreadException(): m_exc(nullptr) {}
+        ThreadException() : m_exc(nullptr) {}
+
         void rethrow() {
             if (m_exc) std::rethrow_exception(m_exc);
         }
-        void capture_exception(){
-            std::unique_lock<std::mutex> guard(m_lock);
+
+        void capture_exception() {
+            std::unique_lock <std::mutex> guard(m_lock);
             m_exc = std::current_exception();
         }
-        template <typename F, typename... P>
-        void run(F f, P... p){
+
+        template<typename F, typename... P>
+        void run(F f, P... p) {
             try {
                 f(p...);
             } catch (...) {
                 capture_exception();
             }
         }
+
         bool holds_exception() { return m_exc != nullptr; }
     };
 }

--- a/include/anyode/anyode_util.hpp
+++ b/include/anyode/anyode_util.hpp
@@ -9,11 +9,9 @@
 #endif
 
 BEGIN_NAMESPACE(AnyODE)
-template<typename T>
-void extend_vec(std::vector<T> &dest, const std::vector<T> &source){
-    dest.reserve(dest.size() + std::distance(source.begin(), source.end()));
-    dest.insert(dest.end(), source.begin(), source.end());
-}
-
-template<class T> void ignore( const T& ) { } // ignore unused parameter compiler warnings, or: `int /* arg */`
+    template<typename T>
+    void extend_vec(std::vector <T> &dest, const std::vector <T> &source) {
+        dest.reserve(dest.size() + std::distance(source.begin(), source.end()));
+        dest.insert(dest.end(), source.begin(), source.end());
+    }
 END_NAMESPACE(AnyODE)

--- a/tests/decomp/Makefile
+++ b/tests/decomp/Makefile
@@ -1,6 +1,9 @@
 CXX ?= g++
-LIBS ?=-llapack -lblas
-CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb
+
+ifeq ($(USE_LAPACK), 1)
+    LIBS ?=-llapack -lblas
+endif
+CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb -DUSE_LAPACK=$(USE_LAPACK)
 CXXFLAGS += $(EXTRA_FLAGS)
 INCLUDE ?= -I../../include
 DEFINES ?=

--- a/tests/decomp/Makefile
+++ b/tests/decomp/Makefile
@@ -1,9 +1,9 @@
 CXX ?= g++
 
-ifeq ($(USE_LAPACK), 1)
+ifeq ($(ANYODE_USE_LAPACK), 1)
     LIBS ?=-llapack -lblas
 endif
-CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb -DUSE_LAPACK=$(USE_LAPACK)
+CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb -DANYODE_USE_LAPACK=$(ANYODE_USE_LAPACK)
 CXXFLAGS += $(EXTRA_FLAGS)
 INCLUDE ?= -I../../include
 DEFINES ?=

--- a/tests/decomp/test_decomp.cpp
+++ b/tests/decomp/test_decomp.cpp
@@ -1,9 +1,74 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
 #include "catch.hpp"
 
+#ifndef USE_LAPACK
+#define USE_LAPACK 0
+#endif
+
+#if USE_LAPACK == 1
 #include "anyode/anyode_decomposition_lapack.hpp"
+#else
+#include "anyode/anyode_decomposition.hpp"
+#endif
 
 
+TEST_CASE( "DenseLU_solve", "[DenseLU]" ) {
+    constexpr int n = 6;
+    constexpr int ld = 8;
+    std::array<double, n*ld> data {{  // column major
+        5,5,1,0,0,0,0,0,
+        3,8,0,2,0,0,0,0,
+        2,0,8,4,3,0,0,0,
+        0,3,4,4,0,4,0,0,
+        0,0,4,0,6,2,0,0,
+        0,0,0,5,9,7,0,0
+    }};
+    bool colmaj = true;
+    AnyODE::DenseMatrix<double> dmv {&data[0], n, n, ld, colmaj};
+    std::array<double, n> xref {{-7, 13, 9, -4, -0.7, 42}};
+    std::array<double, n> x;
+    std::array<double, n> b;
+    dmv.dot_vec(&xref[0], &b[0]);
+    auto decomp = AnyODE::DenseLU<double>(&dmv);
+    int info = decomp.factorize();
+    REQUIRE( info == 0 );
+    int flag = decomp.solve(&b[0], &x[0]);
+    REQUIRE( flag == 0 );
+    for (int idx=0; idx<n; ++idx){
+        REQUIRE( std::abs((x[idx] - xref[idx])/2e-13) < 1 );
+    }
+}
+
+TEST_CASE( "DiagInv_solve", "[Diaginv]" ) {
+    constexpr int n = 6;
+    constexpr int ld = 1;
+    std::array<double, n*ld> data {{2,4,8,5,7,13}};
+    AnyODE::DiagonalMatrix<double> dm {nullptr, n, n, 1};
+    REQUIRE(dm.m_ld == 1);
+    REQUIRE(dm.m_nr == n);
+    REQUIRE(dm.m_nc == n);
+    for (int i=0; i < n; ++i){
+        dm(i, i) = data[i];
+    }
+    std::array<double, n> xref {{-7, 13, 9, -4, -0.7, 42}};
+    std::array<double, n> bref {{-14. ,   52. ,   72. ,  -20. ,   -4.9,  546.}};
+    std::array<double, n> x;
+    std::array<double, n> b;
+    dm.dot_vec(&xref[0], &b[0]);
+    for (int idx=0; idx<n; ++idx){
+        REQUIRE( std::abs((b[idx] - bref[idx])/2e-13) < 1 );
+    }
+    auto decomp = AnyODE::DiagonalInv<double>(&dm);
+    int info = decomp.factorize();
+    REQUIRE( info == 0 );
+    int flag = decomp.solve(&b[0], &x[0]);
+    REQUIRE( flag == 0 );
+    for (int idx=0; idx<n; ++idx){
+        REQUIRE( std::abs((x[idx] - xref[idx])/2e-13) < 1 );
+    }
+}
+
+#if USE_LAPACK == 1
 TEST_CASE( "SVD_solve", "[SVD]" ) {
     constexpr int n = 6;
     constexpr int ld = 8;
@@ -31,33 +96,6 @@ TEST_CASE( "SVD_solve", "[SVD]" ) {
     }
     REQUIRE( decomp.m_condition_number < 10.0 );
 
-}
-
-TEST_CASE( "DenseLU_solve", "[DenseLU]" ) {
-    constexpr int n = 6;
-    constexpr int ld = 8;
-    std::array<double, n*ld> data {{  // column major
-        5,5,1,0,0,0,0,0,
-        3,8,0,2,0,0,0,0,
-        2,0,8,4,3,0,0,0,
-        0,3,4,4,0,4,0,0,
-        0,0,4,0,6,2,0,0,
-        0,0,0,5,9,7,0,0
-    }};
-    bool colmaj = true;
-    AnyODE::DenseMatrix<double> dmv {&data[0], n, n, ld, colmaj};
-    std::array<double, n> xref {{-7, 13, 9, -4, -0.7, 42}};
-    std::array<double, n> x;
-    std::array<double, n> b;
-    dmv.dot_vec(&xref[0], &b[0]);
-    auto decomp = AnyODE::DenseLU<double>(&dmv);
-    int info = decomp.factorize();
-    REQUIRE( info == 0 );
-    int flag = decomp.solve(&b[0], &x[0]);
-    REQUIRE( flag == 0 );
-    for (int idx=0; idx<n; ++idx){
-        REQUIRE( std::abs((x[idx] - xref[idx])/2e-13) < 1 );
-    }
 }
 
 TEST_CASE( "BandedLU_solve", "[BandedLU]" ) {
@@ -101,32 +139,4 @@ TEST_CASE( "BandedLU_solve", "[BandedLU]" ) {
         REQUIRE( std::abs((x[idx] - xref[idx])/2e-13) < 1 );
     }
 }
-
-TEST_CASE( "DiagInv_solve", "[Diaginv]" ) {
-    constexpr int n = 6;
-    constexpr int ld = 1;
-    std::array<double, n*ld> data {{2,4,8,5,7,13}};
-    AnyODE::DiagonalMatrix<double> dm {nullptr, n, n, 1};
-    REQUIRE(dm.m_ld == 1);
-    REQUIRE(dm.m_nr == n);
-    REQUIRE(dm.m_nc == n);
-    for (int i=0; i < n; ++i){
-        dm(i, i) = data[i];
-    }
-    std::array<double, n> xref {{-7, 13, 9, -4, -0.7, 42}};
-    std::array<double, n> bref {{-14. ,   52. ,   72. ,  -20. ,   -4.9,  546.}};
-    std::array<double, n> x;
-    std::array<double, n> b;
-    dm.dot_vec(&xref[0], &b[0]);
-    for (int idx=0; idx<n; ++idx){
-        REQUIRE( std::abs((b[idx] - bref[idx])/2e-13) < 1 );
-    }
-    auto decomp = AnyODE::DiagonalInv<double>(&dm);
-    int info = decomp.factorize();
-    REQUIRE( info == 0 );
-    int flag = decomp.solve(&b[0], &x[0]);
-    REQUIRE( flag == 0 );
-    for (int idx=0; idx<n; ++idx){
-        REQUIRE( std::abs((x[idx] - xref[idx])/2e-13) < 1 );
-    }
-}
+#endif

--- a/tests/decomp/test_decomp.cpp
+++ b/tests/decomp/test_decomp.cpp
@@ -1,11 +1,11 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
 #include "catch.hpp"
 
-#ifndef USE_LAPACK
-#define USE_LAPACK 0
+#ifndef ANYODE_USE_LAPACK
+#define ANYODE_USE_LAPACK 0
 #endif
 
-#if USE_LAPACK == 1
+#if ANYODE_USE_LAPACK == 1
 #include "anyode/anyode_decomposition_lapack.hpp"
 #else
 #include "anyode/anyode_decomposition.hpp"
@@ -68,7 +68,7 @@ TEST_CASE( "DiagInv_solve", "[Diaginv]" ) {
     }
 }
 
-#if USE_LAPACK == 1
+#if ANYODE_USE_LAPACK == 1
 TEST_CASE( "SVD_solve", "[SVD]" ) {
     constexpr int n = 6;
     constexpr int ld = 8;

--- a/tests/eulerfw/_eulerfw.pyx
+++ b/tests/eulerfw/_eulerfw.pyx
@@ -16,14 +16,14 @@ from anyode_numpy cimport PyOdeSys
 cdef class EulerForward:
 
     cdef Integrator * thisptr
-    cdef PyOdeSys * odesys
+    cdef PyOdeSys[double, int] * odesys
 
     def __cinit__(self, int ny, f, cb_kwargs=None, jtimes=None, quads=None, roots=None, jac=None, dx0cb=None, dx_max_cb=None):
         cdef int mlower=-1, mupper=-1, nroots=0, nquads=0, nnz=-1
-        self.odesys = new PyOdeSys(
+        self.odesys = new PyOdeSys[double, int](
             ny, <PyObject *>f, <PyObject *>jac, <PyObject *>jtimes, <PyObject *>quads, <PyObject *>roots, <PyObject *>cb_kwargs,
             mlower, mupper, nquads, nroots, <PyObject *>dx0cb, <PyObject *>dx_max_cb, nnz)
-        self.thisptr = new Integrator(<OdeSysBase[double]*>self.odesys)
+        self.thisptr = new Integrator(<OdeSysBase[double, int]*>self.odesys)
 
     def __dealloc__(self):
         del self.thisptr

--- a/tests/eulerfw/eulerfw.hpp
+++ b/tests/eulerfw/eulerfw.hpp
@@ -4,10 +4,10 @@
 namespace eulerfw {
 
     struct Integrator {
-        AnyODE::OdeSysBase<double> * m_sys;
+        AnyODE::OdeSysBase<double, int> * m_sys;
         const int m_ny;
         double * const m_buffer;
-        Integrator(AnyODE::OdeSysBase<double> * sys) : m_sys(sys), m_ny(m_sys->get_ny()), m_buffer(new double[m_ny]) {}
+        Integrator(AnyODE::OdeSysBase<double, int> * sys) : m_sys(sys), m_ny(m_sys->get_ny()), m_buffer(new double[m_ny]) {}
         ~Integrator() { delete []m_buffer; }
         void integrate(double * const tout, int n_tout, double * const yout) {
             auto t_start = std::chrono::high_resolution_clock::now();

--- a/tests/eulerfw/eulerfw.pxd
+++ b/tests/eulerfw/eulerfw.pxd
@@ -4,5 +4,5 @@ from anyode cimport OdeSysBase
 
 cdef extern from "eulerfw.hpp" namespace "eulerfw":
     cppclass Integrator:
-        Integrator(OdeSysBase[double] *)
+        Integrator(OdeSysBase[double, int] *)
         void integrate(double *, int, double *) except +

--- a/tests/matrix/Makefile
+++ b/tests/matrix/Makefile
@@ -1,10 +1,10 @@
 CXX ?= g++
 
-ifeq ($(USE_LAPACK), 1)
+ifeq ($(ANYODE_USE_LAPACK), 1)
     LIBS ?=-llapack -lblas
 endif
 
-CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb -DUSE_LAPACK=$(USE_LAPACK)
+CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb -DANYODE_USE_LAPACK=$(ANYODE_USE_LAPACK)
 CXXFLAGS += $(EXTRA_FLAGS)
 INCLUDE ?= -I../../include
 DEFINES ?=

--- a/tests/matrix/Makefile
+++ b/tests/matrix/Makefile
@@ -1,6 +1,10 @@
 CXX ?= g++
-LIBS ?=-llapack -lblas
-CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb
+
+ifeq ($(USE_LAPACK), 1)
+    LIBS ?=-llapack -lblas
+endif
+
+CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb -DUSE_LAPACK=$(USE_LAPACK)
 CXXFLAGS += $(EXTRA_FLAGS)
 INCLUDE ?= -I../../include
 DEFINES ?=

--- a/tests/matrix/test_matrix.cpp
+++ b/tests/matrix/test_matrix.cpp
@@ -3,11 +3,11 @@
 
 #include <memory>  // std::unique_ptr
 
-#ifndef USE_LAPACK
-#define USE_LAPACK 0
+#ifndef ANYODE_USE_LAPACK
+#define ANYODE_USE_LAPACK 0
 #endif
 
-#if USE_LAPACK == 1
+#if ANYODE_USE_LAPACK == 1
 #include "anyode/anyode_blas_lapack.hpp"
 #else
 #include "anyode/anyode_blasless.hpp"
@@ -62,7 +62,7 @@ TEST_CASE( "DenseMatrix.copy", "[DenseMatrix]" ) {
     }
 }
 
-#if USE_LAPACK == 1
+#if ANYODE_USE_LAPACK == 1
 TEST_CASE( "banded_padded_from_dense", "[BandedMatrix]" ) {
     REQUIRE( AnyODE::banded_padded_ld(3, 5) == 3*2 + 5 + 1);
     const int n = 6;

--- a/tests/matrix/test_matrix.cpp
+++ b/tests/matrix/test_matrix.cpp
@@ -2,7 +2,16 @@
 #include "catch.hpp"
 
 #include <memory>  // std::unique_ptr
+
+#ifndef USE_LAPACK
+#define USE_LAPACK 0
+#endif
+
+#if USE_LAPACK == 1
 #include "anyode/anyode_blas_lapack.hpp"
+#else
+#include "anyode/anyode_blasless.hpp"
+#endif
 #include "anyode/anyode_matrix.hpp"
 
 
@@ -53,6 +62,7 @@ TEST_CASE( "DenseMatrix.copy", "[DenseMatrix]" ) {
     }
 }
 
+#if USE_LAPACK == 1
 TEST_CASE( "banded_padded_from_dense", "[BandedMatrix]" ) {
     REQUIRE( AnyODE::banded_padded_ld(3, 5) == 3*2 + 5 + 1);
     const int n = 6;
@@ -69,6 +79,7 @@ TEST_CASE( "banded_padded_from_dense", "[BandedMatrix]" ) {
     REQUIRE( std::abs(banded.m_data[5] - 5) < 1e-15 );
     REQUIRE( std::abs(banded.m_data[6] - 1) < 1e-15 );
 }
+#endif
 
 
 AnyODE::DiagonalMatrix<double> * mk_dg(bool own_data=false){


### PR DESCRIPTION
In short, these changes update the AnyODE interface to be generic with respect to the type used
for real values (Real_t), and the type used for index (Index_t). This is motivated by the fact that different platforms/integration libraries may use different precisions for these types, which could complicate subclassing. 

Things of note:

-This *should* be mostly backward-compatible. Although the \* OdeSys \* structs now expect two template arguments (Real_t and Index_t) instead of zero or one, there are defaults and they furthermore correspond to the old fixed types (double, int).
- When to use int vs when to use the new Index_t? As a rule I have only genericized those integers expected to be used directly as an index (such as colptrs, rowvals) or as the size of an array to be indexed (ny, nnz), by an external integration library. All others (such as those internal to AnyODE) are left unchanged.
-All LAPACK-free content has now been shifted to the LAPACK-less portions of the _decomposition and _matrix header files.