### PR TITLE
Use generic real, index types

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -4,4 +4,5 @@ build:
     - ASAN_SYMBOLIZER_PATH=/usr/lib/llvm-6.0/bin/llvm-symbolizer
     - ASAN_OPTIONS=symbolize=1
   commands:
-    - ./scripts/ci.sh
+    - ANYODE_NO_LAPACK=1 ./scripts/ci.sh
+    - ANYODE_NO_LAPACK=0 ./scripts/ci.sh

--- a/README.rst
+++ b/README.rst
@@ -17,6 +17,9 @@ Notes
 When compiled with ``-DNDEBUG`` then ``AnyODE::buffer_factory`` will return a ``std::unique_ptr`` to an (unitizialized)
 array. When compiled without ``NDEBUG`` it will instead return a ``std::vector`` initizlied with signaling NaN.
 
+By default, AnyODE uses BLAS/LAPACK for preconditioning operations on the Jacobian matrix. If you do not have
+(or do not wish to compile with) BLAS/LAPACK, ``-DANYODE_NO_LAPACK=1`` should be set, in which case built-in
+linear algebra routines will be substituted.
 
 License
 -------

--- a/cython_def/anyode.pxd
+++ b/cython_def/anyode.pxd
@@ -6,7 +6,7 @@ from libcpp.vector cimport vector
 from libcpp cimport bool
 
 cdef extern from "anyode/anyode.hpp" namespace "AnyODE":
-     cdef cppclass OdeSysBase[T]:
+     cdef cppclass OdeSysBase[Real_t, Int_t]:
          int nfev, njev, njvev
          bool use_get_dx_max
 

--- a/cython_def/anyode_numpy.pxd
+++ b/cython_def/anyode_numpy.pxd
@@ -4,15 +4,21 @@ from cpython.ref cimport PyObject
 from libcpp cimport bool
 from anyode cimport Info
 
+cdef extern from "numpy/arrayobject.h":
+    ctypedef int NPY_TYPES
+
 cdef extern from "anyode/anyode_numpy.hpp" namespace "AnyODE":
-    cdef cppclass PyOdeSys:
-        PyOdeSys(int, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, int, int, int, int, PyObject*,
-                 PyObject*, int)
-        int get_ny()
+    cdef cppclass PyOdeSys[Real_t, Index_t]:
+        PyOdeSys(Index_t, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, PyObject*, int, int, int, int,
+                 PyObject*, PyObject*, Index_t)
+        Index_t get_ny()
+        Index_t get_nnz()
+        NPY_TYPES int_type_tag
+        NPY_TYPES float_type_tag
         int get_nquads()
         int get_nroots()
-        double get_dx0(double, double *) except +
-        double get_dx_max(double, double *) except +
+        Real_t get_dx0(Real_t, Real_t *) except +
+        Real_t get_dx_max(Real_t, Real_t *) except +
         bool autonomous_exprs
         bool use_get_dx_max
         bool record_rhs_xvals
@@ -23,5 +29,5 @@ cdef extern from "anyode/anyode_numpy.hpp" namespace "AnyODE":
         int mlower, mupper, nroots
         Info current_info
         int nfev, njev, njvev
-        int nnz
+        Index_t nnz
         void * integrator

--- a/include/anyode/anyode.hpp
+++ b/include/anyode/anyode.hpp
@@ -130,7 +130,7 @@ public:
 
 enum class Status : int {success = 0, recoverable_error = 1, unrecoverable_error = -1};
 
-template <typename Real_t=double, typename Index_t=int>
+template<typename Real_t=double, typename Index_t=int>
 struct OdeSysBase {
     int nfev=0, njev=0, njvev=0;
     void * integrator = nullptr;
@@ -145,7 +145,7 @@ struct OdeSysBase {
     bool record_fpe = false;
     bool record_steps = false;
     virtual ~OdeSysBase() {}
-    virtual int get_ny() const = 0;
+    virtual Index_t get_ny() const = 0;
     virtual int get_mlower() const { return -1; } // -1 denotes "not banded"
     virtual int get_mupper() const { return -1; } // -1 denotes "not banded"
     virtual Index_t get_nnz() const { return -1; } // -1 denotes "not sparse"

--- a/include/anyode/anyode_numpy_types.hpp
+++ b/include/anyode/anyode_numpy_types.hpp
@@ -1,0 +1,62 @@
+#pragma once
+
+#include <numpy/arrayobject.h>
+#include <stdint.h>
+
+// Compile-time conversions to (integer-like) numpy TYPENUMs for the "Index_t" PyOdeSys<Real_t, Index_t>
+template<typename T>
+struct has_npy_index_type : std::false_type {
+};
+
+template<typename T>
+struct npy_index_type {
+    static_assert(has_npy_index_type<T>::value, "Cannot find associated numpy integer type for supplied Index_t");
+};
+
+template<>
+struct npy_index_type<int8_t> {
+    const static NPY_TYPES type_tag = NPY_INT8;
+};
+
+template<>
+struct npy_index_type<int16_t> {
+    const static NPY_TYPES type_tag = NPY_INT16;
+};
+
+template<>
+struct npy_index_type<int32_t> {
+    const static NPY_TYPES type_tag = NPY_INT32;
+};
+
+#ifdef INT64_MAX
+template <>
+struct npy_index_type<int64_t>
+{
+    const static NPY_TYPES type_tag = NPY_INT64;
+};
+#endif
+
+// Compile-time conversions to (float-like) numpy TYPENUMs for the "Real_t" in PyOdeSys<Real_t, Index_t>
+template<typename T>
+struct has_npy_real_type : std::false_type {
+};
+
+template<typename T>
+struct npy_real_type {
+    static_assert(has_npy_real_type<T>::value, "Cannot find associated numpy float type for supplied Real_t");
+};
+
+template<>
+struct npy_real_type<float> {
+    const static NPY_TYPES type_tag = NPY_FLOAT;
+};
+
+template<>
+struct npy_real_type<double> {
+    const static NPY_TYPES type_tag = NPY_DOUBLE;
+};
+
+template<>
+struct npy_real_type<long double> {
+    const static NPY_TYPES type_tag = NPY_LONGDOUBLE;
+};

--- a/tests/decomp/Makefile
+++ b/tests/decomp/Makefile
@@ -1,6 +1,9 @@
 CXX ?= g++
+
+ifneq ($(ANYODE_NO_LAPACK), 1)
 LIBS ?=-llapack -lblas
-CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb
+endif
+CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb -DANYODE_NO_LAPACK=$(ANYODE_NO_LAPACK)
 CXXFLAGS += $(EXTRA_FLAGS)
 INCLUDE ?= -I../../include
 DEFINES ?=

--- a/tests/decomp/test_decomp.cpp
+++ b/tests/decomp/test_decomp.cpp
@@ -1,9 +1,17 @@
 #define CATCH_CONFIG_MAIN  // This tells Catch to provide a main()
 #include "catch.hpp"
 
+#ifndef ANYODE_NO_LAPACK
+#define ANYODE_NO_LAPACK 0
+#endif
+
+#if ANYODE_NO_LAPACK == 1
+#include "anyode/anyode_decomposition.hpp"
+#else
 #include "anyode/anyode_decomposition_lapack.hpp"
+#endif
 
-
+#if ANYODE_NO_LAPACK != 1
 TEST_CASE( "SVD_solve", "[SVD]" ) {
     constexpr int n = 6;
     constexpr int ld = 8;
@@ -32,6 +40,7 @@ TEST_CASE( "SVD_solve", "[SVD]" ) {
     REQUIRE( decomp.m_condition_number < 10.0 );
 
 }
+#endif
 
 TEST_CASE( "DenseLU_solve", "[DenseLU]" ) {
     constexpr int n = 6;
@@ -60,6 +69,7 @@ TEST_CASE( "DenseLU_solve", "[DenseLU]" ) {
     }
 }
 
+#if ANYODE_NO_LAPACK != 1
 TEST_CASE( "BandedLU_solve", "[BandedLU]" ) {
     constexpr int n = 6;
     constexpr int ld = 8;
@@ -101,6 +111,7 @@ TEST_CASE( "BandedLU_solve", "[BandedLU]" ) {
         REQUIRE( std::abs((x[idx] - xref[idx])/2e-13) < 1 );
     }
 }
+#endif
 
 TEST_CASE( "DiagInv_solve", "[Diaginv]" ) {
     constexpr int n = 6;

--- a/tests/eulerfw/_eulerfw.pyx
+++ b/tests/eulerfw/_eulerfw.pyx
@@ -16,14 +16,14 @@ from anyode_numpy cimport PyOdeSys
 cdef class EulerForward:
 
     cdef Integrator * thisptr
-    cdef PyOdeSys * odesys
+    cdef PyOdeSys[double, int] * odesys
 
     def __cinit__(self, int ny, f, cb_kwargs=None, jtimes=None, quads=None, roots=None, jac=None, dx0cb=None, dx_max_cb=None):
         cdef int mlower=-1, mupper=-1, nroots=0, nquads=0, nnz=-1
-        self.odesys = new PyOdeSys(
+        self.odesys = new PyOdeSys[double, int](
             ny, <PyObject *>f, <PyObject *>jac, <PyObject *>jtimes, <PyObject *>quads, <PyObject *>roots, <PyObject *>cb_kwargs,
             mlower, mupper, nquads, nroots, <PyObject *>dx0cb, <PyObject *>dx_max_cb, nnz)
-        self.thisptr = new Integrator(<OdeSysBase[double]*>self.odesys)
+        self.thisptr = new Integrator(<OdeSysBase[double, int]*>self.odesys)
 
     def __dealloc__(self):
         del self.thisptr

--- a/tests/eulerfw/eulerfw.hpp
+++ b/tests/eulerfw/eulerfw.hpp
@@ -4,10 +4,10 @@
 namespace eulerfw {
 
     struct Integrator {
-        AnyODE::OdeSysBase<double> * m_sys;
+        AnyODE::OdeSysBase<double, int> * m_sys;
         const int m_ny;
         double * const m_buffer;
-        Integrator(AnyODE::OdeSysBase<double> * sys) : m_sys(sys), m_ny(m_sys->get_ny()), m_buffer(new double[m_ny]) {}
+        Integrator(AnyODE::OdeSysBase<double, int> * sys) : m_sys(sys), m_ny(m_sys->get_ny()), m_buffer(new double[m_ny]) {}
         ~Integrator() { delete []m_buffer; }
         void integrate(double * const tout, int n_tout, double * const yout) {
             auto t_start = std::chrono::high_resolution_clock::now();

--- a/tests/eulerfw/eulerfw.pxd
+++ b/tests/eulerfw/eulerfw.pxd
@@ -4,5 +4,5 @@ from anyode cimport OdeSysBase
 
 cdef extern from "eulerfw.hpp" namespace "eulerfw":
     cppclass Integrator:
-        Integrator(OdeSysBase[double] *)
+        Integrator(OdeSysBase[double, int] *)
         void integrate(double *, int, double *) except +

--- a/tests/matrix/Makefile
+++ b/tests/matrix/Makefile
@@ -1,6 +1,10 @@
 CXX ?= g++
+
+ifneq ($(ANYODE_NO_LAPACK), 1)
 LIBS ?=-llapack -lblas
-CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb
+endif
+
+CXXFLAGS ?= -std=c++11 -Wall -Wextra -Werror -pedantic -g -ggdb -DANYODE_NO_LAPACK=$(ANYODE_NO_LAPACK)
 CXXFLAGS += $(EXTRA_FLAGS)
 INCLUDE ?= -I../../include
 DEFINES ?=

--- a/tests/matrix/test_matrix.cpp
+++ b/tests/matrix/test_matrix.cpp
@@ -2,8 +2,17 @@
 #include "catch.hpp"
 
 #include <memory>  // std::unique_ptr
-#include "anyode/anyode_blas_lapack.hpp"
 #include "anyode/anyode_matrix.hpp"
+
+#ifndef ANYODE_NO_LAPACK
+#define ANYODE_NO_LAPACK 0
+#endif
+
+#if ANYODE_NO_LAPACK == 1
+#include "anyode/anyode_blasless.hpp"
+#else
+#include "anyode/anyode_blas_lapack.hpp"
+#endif
 
 
 AnyODE::DenseMatrix<double> * mk_dm(bool own_data=false){
@@ -53,6 +62,7 @@ TEST_CASE( "DenseMatrix.copy", "[DenseMatrix]" ) {
     }
 }
 
+#if ANYODE_NO_LAPACK != 1
 TEST_CASE( "banded_padded_from_dense", "[BandedMatrix]" ) {
     REQUIRE( AnyODE::banded_padded_ld(3, 5) == 3*2 + 5 + 1);
     const int n = 6;
@@ -69,7 +79,7 @@ TEST_CASE( "banded_padded_from_dense", "[BandedMatrix]" ) {
     REQUIRE( std::abs(banded.m_data[5] - 5) < 1e-15 );
     REQUIRE( std::abs(banded.m_data[6] - 1) < 1e-15 );
 }
-
+#endif
 
 AnyODE::DiagonalMatrix<double> * mk_dg(bool own_data=false){
     constexpr int n = 6;


### PR DESCRIPTION
Let's try this again, with formatting more faithful to the master!

Changes double and int--respectively used for "real number"- and index-like variables--with
templated Real_t and Index_t typenames. Designed to enhance compatibility and subclass-ability
for platforms and integration libraries using different precisions and/or integer widths.

I have respected the current release by assuming LAPACK unless disabled with -DANYODE_NO_LAPACK=1. The opposite is also an option (default=no LAPACK, enabled by -DANYODE_USE_LAPACK=1).